### PR TITLE
Fix caseload bar to not show warning tag in `prod`

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -35,7 +35,7 @@ export default {
   buildNumber: get('BUILD_NUMBER', '2023-05-18.1.39b1b24', requiredInProduction),
   gitRef: get('GIT_REF', 'unknown', requiredInProduction),
   environment: process.env.ENVIRONMENT || 'local',
-  production,
+  production, // NB: this is true in _all_ deployed environments
   https: production,
   staticResourceCacheDuration: '1h',
   redis: {

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -13,6 +13,7 @@ export default function nunjucksSetup(app: express.Express, applicationInfo: App
 
   app.locals.asset_path = '/assets/'
   app.locals.applicationName = 'Non-associations'
+  app.locals.production = config.production
   app.locals.environment = config.environment
 
   app.locals.dpsUrl = config.dpsUrl

--- a/server/views/partials/caseloadBar.njk
+++ b/server/views/partials/caseloadBar.njk
@@ -1,7 +1,7 @@
 {%- from "govuk/components/tag/macro.njk" import govukTag -%}
 
 <div class="dps-caseload-bar">
-  {% if environment != "production" %}
+  {% if environment != "prod" %}
     {{ govukTag({
       text: environment,
       classes: "govuk-!-margin-right-1 govuk-tag--red"


### PR DESCRIPTION
…and point out that `production` config & template parameter is true in dev, preprod _and_ prod