### PR TITLE
Ensure that all route parameters are provided to request handlers

### DIFF
--- a/server/routes/add.ts
+++ b/server/routes/add.ts
@@ -5,7 +5,7 @@ import type { Services } from '../services'
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export default function addRoutes(service: Services): Router {
-  const router = Router()
+  const router = Router({ mergeParams: true })
   const get = (path: string | string[], handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
 
   get('/', (req, res) => {

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -7,7 +7,7 @@ import addRoutes from './add'
 import viewRoutes from './view'
 
 export default function routes(services: Services): Router {
-  const router = Router()
+  const router = Router({ mergeParams: true })
   const get = (path: string | string[], handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
 
   const urlTemplates = services.routeUrls.templates

--- a/server/routes/prisonerSearch.ts
+++ b/server/routes/prisonerSearch.ts
@@ -5,7 +5,7 @@ import type { Services } from '../services'
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export default function prisonerSearchRoutes(service: Services): Router {
-  const router = Router()
+  const router = Router({ mergeParams: true })
   const get = (path: string | string[], handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
 
   get('/', (req, res) => {

--- a/server/routes/view.ts
+++ b/server/routes/view.ts
@@ -5,7 +5,7 @@ import type { Services } from '../services'
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export default function viewRoutes(service: Services): Router {
-  const router = Router()
+  const router = Router({ mergeParams: true })
   const get = (path: string | string[], handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
 
   get('/', (req, res) => {


### PR DESCRIPTION
When a router has sub-routes added, they do not automatically propagate path-based parameters.
This change allows inner routes to also see, for instance, the `prisonerNumber` parameter