### PR TITLE
NON-104: Copy sortable table styles from incentives-ui

### DIFF
--- a/assets/scss/application.scss
+++ b/assets/scss/application.scss
@@ -7,9 +7,10 @@ $govuk-page-width: $moj-page-width;
 @import 'govuk/all';
 @import 'moj/all';
 
-@import './components/header';
-@import './components/caseload-bar';
 @import './components/card';
+@import './components/caseload-bar';
 @import './components/error-pages';
+@import './components/header';
+@import './components/sortable-table';
 
 @import './local';

--- a/assets/scss/components/_sortable-table.scss
+++ b/assets/scss/components/_sortable-table.scss
@@ -1,0 +1,62 @@
+@include govuk-media-query($until: desktop) {
+  .app-sortable-table-container {
+    overflow-x: scroll;
+
+    .app-sortable-table {
+      min-width: $moj-page-width;
+    }
+  }
+}
+
+.app-sortable-table {
+  .govuk-table__header {
+    padding: govuk-spacing(4) govuk-spacing(4) govuk-spacing(4) 0;
+  }
+
+  thead {
+    th a {
+      display: inline-block;
+      position: relative;
+      padding-right: 20px;
+      color: $govuk-link-colour;
+
+      &::before, &::after {
+        position: absolute;
+        right: 0;
+        font-size: 14px;
+        line-height: 1;
+      }
+    }
+
+    th[aria-sort='none'] {
+      a::before {
+        content: ' ▲' / '';
+        top: 0;
+        font-size: 12px;
+        color: govuk-colour('mid-grey');
+      }
+      a::after {
+        content: ' ▼' / '';
+        top: 12px;
+        font-size: 12px;
+        color: govuk-colour('mid-grey');
+      }
+    }
+
+    th[aria-sort='ascending'] {
+      a::before {
+        content: ' ▲' / '';
+        top: 4px;
+        color: govuk-colour('black');
+      }
+    }
+
+    th[aria-sort='descending'] {
+      a::after {
+        content: ' ▼' / '';
+        top: 6px;
+        color: govuk-colour('black');
+      }
+    }
+  }
+}


### PR DESCRIPTION
… which can be used with the [GOV.UK Table component](https://design-system.service.gov.uk/components/table/) to style it _similarly_ to the [MoJ Sortable table component](https://design-patterns.service.justice.gov.uk/components/sortable-table/).

```html
<div class="app-sortable-table-container">
  {{ govukTable({
    …
    classes: "app-sortable-table"
  }) }}
</div>
```

NB: the MoJ Sortable table component is only able to sort one page’s worth of rows _in the browser_, it cannot work with data that is sorted on the back-end. The above code makes a regular GOV.UK Table _look_ like this component.