### PR TITLE
NON-104: Load the key prisoner’s details

### DIFF
--- a/server/middleware/breadcrumbs.ts
+++ b/server/middleware/breadcrumbs.ts
@@ -11,10 +11,6 @@ export class Breadcrumbs {
         text: 'Digital Prison Services',
         href: res.app.locals.dpsUrl,
       },
-      {
-        text: 'Jones, David',
-        href: `${res.app.locals.dpsUrl}/prisoner/A8469DY`,
-      },
     ]
   }
 

--- a/server/routes/add.test.ts
+++ b/server/routes/add.test.ts
@@ -1,10 +1,10 @@
 import type { Express } from 'express'
 import request from 'supertest'
 
-import { SanitisedError } from '../sanitisedError'
 import { appWithAllRoutes } from './testutils/appSetup'
 import routeUrls from '../services/routeUrls'
 import { OffenderSearchClient } from '../data/offenderSearch'
+import { SanitisedError } from '../sanitisedError'
 
 jest.mock('../data/hmppsAuthClient')
 jest.mock('../data/offenderSearch')
@@ -18,6 +18,9 @@ const prisoner = {
   firstName: 'DAVID',
   lastName: 'JONES',
 }
+
+// mock "other" prisoner
+const otherPrisonerNumber = 'A1235EF'
 
 let app: Express
 let offenderSearchClient: jest.Mocked<OffenderSearchClient>
@@ -33,7 +36,7 @@ afterEach(() => {
   jest.resetAllMocks()
 })
 
-describe('Non-associations list page', () => {
+describe('Add non-association details page', () => {
   it('should return 404 if prisoner is not found', () => {
     const error: SanitisedError = {
       name: 'Error',
@@ -44,7 +47,7 @@ describe('Non-associations list page', () => {
     offenderSearchClient.getPrisoner.mockRejectedValue(error)
 
     return request(app)
-      .get(routeUrls.view(prisonerNumber))
+      .get(routeUrls.add(prisonerNumber, otherPrisonerNumber))
       .expect(404)
       .expect(res => {
         expect(res.text).not.toContain('Jones, David')
@@ -53,7 +56,7 @@ describe('Non-associations list page', () => {
 
   it('should render breadcrumbs', () => {
     return request(app)
-      .get(routeUrls.view(prisonerNumber))
+      .get(routeUrls.add(prisonerNumber, otherPrisonerNumber))
       .expect(200)
       .expect('Content-Type', /html/)
       .expect(res => {

--- a/server/routes/add.test.ts
+++ b/server/routes/add.test.ts
@@ -21,6 +21,13 @@ const prisoner = {
 
 // mock "other" prisoner
 const otherPrisonerNumber = 'A1235EF'
+const otherPrisoner = {
+  prisonId: 'MDI',
+  bookingId: 12346,
+  prisonerNumber: otherPrisonerNumber,
+  firstName: 'FRED',
+  lastName: 'MILLS',
+}
 
 let app: Express
 let offenderSearchClient: jest.Mocked<OffenderSearchClient>
@@ -29,7 +36,6 @@ beforeEach(() => {
   app = appWithAllRoutes({})
 
   offenderSearchClient = OffenderSearchClient.prototype as jest.Mocked<OffenderSearchClient>
-  offenderSearchClient.getPrisoner.mockResolvedValue(prisoner)
 })
 
 afterEach(() => {
@@ -51,16 +57,40 @@ describe('Add non-association details page', () => {
       .expect(404)
       .expect(res => {
         expect(res.text).not.toContain('Jones, David')
+        expect(offenderSearchClient.getPrisoner.mock.calls).toHaveLength(1)
+      })
+  })
+
+  it('should return 404 if other prisoner is not found', () => {
+    offenderSearchClient.getPrisoner.mockResolvedValueOnce(prisoner)
+    const error: SanitisedError = {
+      name: 'Error',
+      status: 404,
+      message: 'Not Found',
+      stack: 'Not Found',
+    }
+    offenderSearchClient.getPrisoner.mockRejectedValueOnce(error)
+
+    return request(app)
+      .get(routeUrls.add(prisonerNumber, otherPrisonerNumber))
+      .expect(404)
+      .expect(res => {
+        expect(res.text).not.toContain('Jones, David')
+        expect(offenderSearchClient.getPrisoner.mock.calls).toHaveLength(2)
       })
   })
 
   it('should render breadcrumbs', () => {
+    offenderSearchClient.getPrisoner.mockResolvedValueOnce(prisoner)
+    offenderSearchClient.getPrisoner.mockResolvedValueOnce(otherPrisoner)
+
     return request(app)
       .get(routeUrls.add(prisonerNumber, otherPrisonerNumber))
       .expect(200)
       .expect('Content-Type', /html/)
       .expect(res => {
         expect(res.text).toContain('Jones, David')
+        expect(offenderSearchClient.getPrisoner.mock.calls).toHaveLength(2)
       })
   })
 })

--- a/server/routes/add.ts
+++ b/server/routes/add.ts
@@ -1,6 +1,6 @@
 import { type RequestHandler, Router } from 'express'
 
-import { nameOfPrisoner } from '../utils/utils'
+import { nameOfPrisoner, reversedNameOfPrisoner } from '../utils/utils'
 import asyncMiddleware from '../middleware/asyncMiddleware'
 import HmppsAuthClient from '../data/hmppsAuthClient'
 import { OffenderSearchClient } from '../data/offenderSearch'
@@ -10,7 +10,6 @@ import type { Services } from '../services'
 
 const hmppsAuthClient = new HmppsAuthClient(new TokenStore(createRedisClient()))
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export default function addRoutes(service: Services): Router {
   const router = Router({ mergeParams: true })
   const get = (path: string | string[], handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
@@ -22,8 +21,10 @@ export default function addRoutes(service: Services): Router {
     const offenderSearchClient = new OffenderSearchClient(systemToken)
     const prisoner = await offenderSearchClient.getPrisoner(prisonerNumber)
 
-    res.locals.breadcrumbs.addItems({ text: 'Non-associations', href: req.originalUrl })
-
+    res.locals.breadcrumbs.addItems(
+      { text: reversedNameOfPrisoner(prisoner), href: `${res.app.locals.dpsUrl}/prisoner/${prisonerNumber}` },
+      { text: 'Non-associations', href: service.routeUrls.view(prisonerNumber) },
+    )
     res.render('pages/add.njk', {
       prisonerNumber,
       prisonerName: nameOfPrisoner(prisoner),

--- a/server/routes/add.ts
+++ b/server/routes/add.ts
@@ -15,11 +15,12 @@ export default function addRoutes(service: Services): Router {
   const get = (path: string | string[], handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
 
   get('/', async (req, res) => {
-    const { prisonerNumber } = req.params
+    const { prisonerNumber, otherPrisonerNumber } = req.params
 
     const systemToken = await hmppsAuthClient.getSystemClientToken(res.locals.user.username)
     const offenderSearchClient = new OffenderSearchClient(systemToken)
     const prisoner = await offenderSearchClient.getPrisoner(prisonerNumber)
+    const otherPrisoner = await offenderSearchClient.getPrisoner(otherPrisonerNumber)
 
     res.locals.breadcrumbs.addItems(
       { text: reversedNameOfPrisoner(prisoner), href: `${res.app.locals.dpsUrl}/prisoner/${prisonerNumber}` },
@@ -28,6 +29,8 @@ export default function addRoutes(service: Services): Router {
     res.render('pages/add.njk', {
       prisonerNumber,
       prisonerName: nameOfPrisoner(prisoner),
+      otherPrisonerNumber,
+      otherPrisonerName: nameOfPrisoner(otherPrisoner),
     })
   })
 

--- a/server/routes/add.ts
+++ b/server/routes/add.ts
@@ -1,17 +1,33 @@
 import { type RequestHandler, Router } from 'express'
 
+import { nameOfPrisoner } from '../utils/utils'
 import asyncMiddleware from '../middleware/asyncMiddleware'
+import HmppsAuthClient from '../data/hmppsAuthClient'
+import { OffenderSearchClient } from '../data/offenderSearch'
+import { createRedisClient } from '../data/redisClient'
+import TokenStore from '../data/tokenStore'
 import type { Services } from '../services'
+
+const hmppsAuthClient = new HmppsAuthClient(new TokenStore(createRedisClient()))
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export default function addRoutes(service: Services): Router {
   const router = Router({ mergeParams: true })
   const get = (path: string | string[], handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
 
-  get('/', (req, res) => {
+  get('/', async (req, res) => {
+    const { prisonerNumber } = req.params
+
+    const systemToken = await hmppsAuthClient.getSystemClientToken(res.locals.user.username)
+    const offenderSearchClient = new OffenderSearchClient(systemToken)
+    const prisoner = await offenderSearchClient.getPrisoner(prisonerNumber)
+
     res.locals.breadcrumbs.addItems({ text: 'Non-associations', href: req.originalUrl })
 
-    res.render('pages/add.njk')
+    res.render('pages/add.njk', {
+      prisonerNumber,
+      prisonerName: nameOfPrisoner(prisoner),
+    })
   })
 
   return router

--- a/server/routes/prisonerSearch.test.ts
+++ b/server/routes/prisonerSearch.test.ts
@@ -48,6 +48,7 @@ describe('Search for a prisoner page', () => {
       .expect(404)
       .expect(res => {
         expect(res.text).not.toContain('Jones, David')
+        expect(offenderSearchClient.getPrisoner.mock.calls).toHaveLength(1)
       })
   })
 

--- a/server/routes/prisonerSearch.test.ts
+++ b/server/routes/prisonerSearch.test.ts
@@ -1,10 +1,10 @@
 import type { Express } from 'express'
 import request from 'supertest'
 
-import { SanitisedError } from '../sanitisedError'
 import { appWithAllRoutes } from './testutils/appSetup'
 import routeUrls from '../services/routeUrls'
 import { OffenderSearchClient } from '../data/offenderSearch'
+import { SanitisedError } from '../sanitisedError'
 
 jest.mock('../data/hmppsAuthClient')
 jest.mock('../data/offenderSearch')
@@ -33,7 +33,7 @@ afterEach(() => {
   jest.resetAllMocks()
 })
 
-describe('Non-associations list page', () => {
+describe('Search for a prisoner page', () => {
   it('should return 404 if prisoner is not found', () => {
     const error: SanitisedError = {
       name: 'Error',
@@ -44,7 +44,7 @@ describe('Non-associations list page', () => {
     offenderSearchClient.getPrisoner.mockRejectedValue(error)
 
     return request(app)
-      .get(routeUrls.view(prisonerNumber))
+      .get(routeUrls.prisonerSearch(prisonerNumber))
       .expect(404)
       .expect(res => {
         expect(res.text).not.toContain('Jones, David')
@@ -53,7 +53,7 @@ describe('Non-associations list page', () => {
 
   it('should render breadcrumbs', () => {
     return request(app)
-      .get(routeUrls.view(prisonerNumber))
+      .get(routeUrls.prisonerSearch(prisonerNumber))
       .expect(200)
       .expect('Content-Type', /html/)
       .expect(res => {

--- a/server/routes/prisonerSearch.ts
+++ b/server/routes/prisonerSearch.ts
@@ -1,17 +1,33 @@
 import { type RequestHandler, Router } from 'express'
 
+import { nameOfPrisoner } from '../utils/utils'
 import asyncMiddleware from '../middleware/asyncMiddleware'
+import HmppsAuthClient from '../data/hmppsAuthClient'
+import { OffenderSearchClient } from '../data/offenderSearch'
+import { createRedisClient } from '../data/redisClient'
+import TokenStore from '../data/tokenStore'
 import type { Services } from '../services'
+
+const hmppsAuthClient = new HmppsAuthClient(new TokenStore(createRedisClient()))
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export default function prisonerSearchRoutes(service: Services): Router {
   const router = Router({ mergeParams: true })
   const get = (path: string | string[], handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
 
-  get('/', (req, res) => {
+  get('/', async (req, res) => {
+    const { prisonerNumber } = req.params
+
+    const systemToken = await hmppsAuthClient.getSystemClientToken(res.locals.user.username)
+    const offenderSearchClient = new OffenderSearchClient(systemToken)
+    const prisoner = await offenderSearchClient.getPrisoner(prisonerNumber)
+
     res.locals.breadcrumbs.addItems({ text: 'Non-associations', href: req.originalUrl })
 
-    res.render('pages/prisonerSearch.njk')
+    res.render('pages/prisonerSearch.njk', {
+      prisonerNumber,
+      prisonerName: nameOfPrisoner(prisoner),
+    })
   })
 
   return router

--- a/server/routes/prisonerSearch.ts
+++ b/server/routes/prisonerSearch.ts
@@ -1,6 +1,6 @@
 import { type RequestHandler, Router } from 'express'
 
-import { nameOfPrisoner } from '../utils/utils'
+import { nameOfPrisoner, reversedNameOfPrisoner } from '../utils/utils'
 import asyncMiddleware from '../middleware/asyncMiddleware'
 import HmppsAuthClient from '../data/hmppsAuthClient'
 import { OffenderSearchClient } from '../data/offenderSearch'
@@ -10,7 +10,6 @@ import type { Services } from '../services'
 
 const hmppsAuthClient = new HmppsAuthClient(new TokenStore(createRedisClient()))
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export default function prisonerSearchRoutes(service: Services): Router {
   const router = Router({ mergeParams: true })
   const get = (path: string | string[], handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
@@ -22,8 +21,10 @@ export default function prisonerSearchRoutes(service: Services): Router {
     const offenderSearchClient = new OffenderSearchClient(systemToken)
     const prisoner = await offenderSearchClient.getPrisoner(prisonerNumber)
 
-    res.locals.breadcrumbs.addItems({ text: 'Non-associations', href: req.originalUrl })
-
+    res.locals.breadcrumbs.addItems(
+      { text: reversedNameOfPrisoner(prisoner), href: `${res.app.locals.dpsUrl}/prisoner/${prisonerNumber}` },
+      { text: 'Non-associations', href: service.routeUrls.view(prisonerNumber) },
+    )
     res.render('pages/prisonerSearch.njk', {
       prisonerNumber,
       prisonerName: nameOfPrisoner(prisoner),

--- a/server/routes/view.test.ts
+++ b/server/routes/view.test.ts
@@ -48,6 +48,7 @@ describe('Non-associations list page', () => {
       .expect(404)
       .expect(res => {
         expect(res.text).not.toContain('Jones, David')
+        expect(offenderSearchClient.getPrisoner.mock.calls).toHaveLength(1)
       })
   })
 

--- a/server/routes/view.ts
+++ b/server/routes/view.ts
@@ -1,13 +1,27 @@
 import { type RequestHandler, Router } from 'express'
 
+import { nameOfPrisoner } from '../utils/utils'
 import asyncMiddleware from '../middleware/asyncMiddleware'
+import HmppsAuthClient from '../data/hmppsAuthClient'
+import { OffenderSearchClient } from '../data/offenderSearch'
+import { createRedisClient } from '../data/redisClient'
+import TokenStore from '../data/tokenStore'
 import type { Services } from '../services'
+
+const hmppsAuthClient = new HmppsAuthClient(new TokenStore(createRedisClient()))
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export default function viewRoutes(service: Services): Router {
   const router = Router({ mergeParams: true })
   const get = (path: string | string[], handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
 
-  get('/', (req, res) => {
+  get('/', async (req, res) => {
+    const { prisonerNumber } = req.params
+
+    const systemToken = await hmppsAuthClient.getSystemClientToken(res.locals.user.username)
+    const offenderSearchClient = new OffenderSearchClient(systemToken)
+    const prisoner = await offenderSearchClient.getPrisoner(prisonerNumber)
+
     const response = [
       {
         otherPrisonerName: 'Broadstairs, Liam',
@@ -20,8 +34,10 @@ export default function viewRoutes(service: Services): Router {
         dateAdded: '24 May 2023 by Mary Smith',
       },
     ]
+
     res.render('pages/view.njk', {
-      prisonerName: 'David Jones',
+      prisonerNumber,
+      prisonerName: nameOfPrisoner(prisoner),
       nonAssociations: response,
     })
   })

--- a/server/routes/view.ts
+++ b/server/routes/view.ts
@@ -1,6 +1,6 @@
 import { type RequestHandler, Router } from 'express'
 
-import { nameOfPrisoner } from '../utils/utils'
+import { nameOfPrisoner, reversedNameOfPrisoner } from '../utils/utils'
 import asyncMiddleware from '../middleware/asyncMiddleware'
 import HmppsAuthClient from '../data/hmppsAuthClient'
 import { OffenderSearchClient } from '../data/offenderSearch'
@@ -35,6 +35,10 @@ export default function viewRoutes(service: Services): Router {
       },
     ]
 
+    res.locals.breadcrumbs.addItems({
+      text: reversedNameOfPrisoner(prisoner),
+      href: `${res.app.locals.dpsUrl}/prisoner/${prisonerNumber}`,
+    })
     res.render('pages/view.njk', {
       prisonerNumber,
       prisonerName: nameOfPrisoner(prisoner),

--- a/server/sanitisedError.ts
+++ b/server/sanitisedError.ts
@@ -1,10 +1,10 @@
 import type { ResponseError } from 'superagent'
 
-export interface SanitisedError extends Error {
+export interface SanitisedError<Data = unknown> extends Error {
   text?: string
   status?: number
   headers?: unknown
-  data?: unknown
+  data?: Data
   stack: string
   message: string
 }

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -7,7 +7,7 @@ import express from 'express'
 import config from '../config'
 import type { Services } from '../services'
 import format from './format'
-import { convertToTitleCase, initialiseName } from './utils'
+import { convertToTitleCase, initialiseName, nameOfPrisoner, reversedNameOfPrisoner } from './utils'
 
 export default function nunjucksSetup(app: express.Express, services: Services): void {
   app.set('view engine', 'njk')
@@ -52,6 +52,8 @@ export default function nunjucksSetup(app: express.Express, services: Services):
   // name formatting
   njkEnv.addFilter('convertToTitleCase', convertToTitleCase)
   njkEnv.addFilter('initialiseName', initialiseName)
+  njkEnv.addFilter('nameOfPrisoner', nameOfPrisoner)
+  njkEnv.addFilter('reversedNameOfPrisoner', reversedNameOfPrisoner)
   njkEnv.addFilter('possessiveName', format.possessiveName)
 
   // date & number formatting

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -1,4 +1,4 @@
-import { convertToTitleCase, initialiseName } from './utils'
+import { convertToTitleCase, initialiseName, nameOfPrisoner, reversedNameOfPrisoner } from './utils'
 
 describe('convert to title case', () => {
   it.each([
@@ -26,5 +26,20 @@ describe('initialise name', () => {
     ['Double barrelled', 'Robert-John Smith-Jones-Wilson', 'R. Smith-Jones-Wilson'],
   ])('%s initialiseName(%s, %s)', (_: string, a: string, expected: string) => {
     expect(initialiseName(a)).toEqual(expected)
+  })
+})
+
+describe('display of prisoner names', () => {
+  const prisoner = {
+    firstName: 'DAVID',
+    lastName: 'JONES',
+  }
+
+  it('normal', () => {
+    expect(nameOfPrisoner(prisoner)).toEqual('David Jones')
+  })
+
+  it('reversed', () => {
+    expect(reversedNameOfPrisoner(prisoner)).toEqual('Jones, David')
   })
 })

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -21,3 +21,17 @@ export const initialiseName = (fullName?: string): string | null => {
   const array = fullName.split(' ')
   return `${array[0][0]}. ${array.reverse()[0]}`
 }
+
+/**
+ * Normal display form of a prisoner’s name
+ * { "firstName": "DAVID", "lastName": "JONES", … } → "David Jones"
+ */
+export const nameOfPrisoner = (prisoner: { firstName: string; lastName: string }): string =>
+  `${convertToTitleCase(prisoner.firstName)} ${convertToTitleCase(prisoner.lastName)}`
+
+/**
+ * Display form of a prisoner’s name for lists and tables
+ * { "firstName": "DAVID", "lastName": "JONES", … } → "Jones, David"
+ */
+export const reversedNameOfPrisoner = (prisoner: { firstName: string; lastName: string }): string =>
+  `${convertToTitleCase(prisoner.lastName)}, ${convertToTitleCase(prisoner.firstName)}`

--- a/server/views/pages/add.njk
+++ b/server/views/pages/add.njk
@@ -9,6 +9,9 @@
       <span class="govuk-caption-l">Non-associations</span>
       <h1 class="govuk-heading-l">Non-association details</h1>
 
+      {# TODO: remove once role radio buttons exist #}
+      <!-- {{ otherPrisonerName }} -->
+
     </div>
   </div>
 {% endblock %}


### PR DESCRIPTION
All "add" and "view" pages/routes have the concept of a key prisoner. This person’s details need to be loaded when the routes are being processed. If the person is not found: 404.