### PR TITLE
NON-104 & NON-105: Update non-associations api client to match latest (WIP) data model

### DIFF
--- a/integration_tests/mockApis/nonAssociationsApi.ts
+++ b/integration_tests/mockApis/nonAssociationsApi.ts
@@ -1,12 +1,14 @@
 import type { SuperAgentRequest } from 'superagent'
 
 import { stubFor } from './wiremock'
-import type { LegacyNonAssociationsList } from '../../server/data/nonAssociationsApi'
+import type { NonAssociationsList } from '../../server/data/nonAssociationsApi'
 import {
-  sampleEmptyLegacyNonAssociation,
-  sampleSingleLegacyNonAssociation,
-  sampleMultipleLegacyNonAssociation,
+  davidJones0NonAssociations,
+  davidJones1OpenNonAssociation,
+  davidJones2OpenNonAssociations,
+  nonAssociation,
 } from '../../server/data/testData/nonAssociationsApi'
+import { davidJones, fredMills } from '../../server/data/testData/offenderSearch'
 
 export default {
   stubNonAssociationsApiPing: (): SuperAgentRequest => {
@@ -23,31 +25,45 @@ export default {
     })
   },
 
-  stubLegacyNonAssociations: ({
-    bookingId = 100001,
-    returning = 'multiple',
+  stubListNonAssociations: ({
+    prisonerNumber = davidJones.prisonerNumber,
+    returning = 'twoOpen',
   }: {
-    bookingId?: number
-    returning?: 'empty' | 'single' | 'multiple'
+    prisonerNumber?: string
+    returning?: 'none' | 'oneOpen' | 'twoOpen'
   } = {}): SuperAgentRequest => {
-    let nonAssociationsList: LegacyNonAssociationsList
-    if (returning === 'empty') {
-      nonAssociationsList = sampleEmptyLegacyNonAssociation
-    } else if (returning === 'single') {
-      nonAssociationsList = sampleSingleLegacyNonAssociation
+    let nonAssociationsList: NonAssociationsList
+    if (returning === 'none') {
+      nonAssociationsList = davidJones0NonAssociations
+    } else if (returning === 'oneOpen') {
+      nonAssociationsList = davidJones1OpenNonAssociation
     } else {
-      nonAssociationsList = sampleMultipleLegacyNonAssociation
+      nonAssociationsList = davidJones2OpenNonAssociations
     }
 
     return stubFor({
       request: {
         method: 'GET',
-        urlPattern: `/nonAssociationsApi/legacy/api/bookings/${bookingId}/non-association-details`,
+        urlPattern: `/prisoner/${encodeURIComponent(prisonerNumber)}/non-associations`,
       },
       response: {
         status: 200,
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
         jsonBody: nonAssociationsList,
+      },
+    })
+  },
+
+  stubAddNonAssociation: () => {
+    return stubFor({
+      request: {
+        method: 'POST',
+        urlPattern: '/non-associations',
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: nonAssociation(davidJones.prisonerNumber, fredMills.prisonerNumber),
       },
     })
   },

--- a/integration_tests/mockApis/nonAssociationsApi.ts
+++ b/integration_tests/mockApis/nonAssociationsApi.ts
@@ -6,9 +6,13 @@ import {
   davidJones0NonAssociations,
   davidJones1OpenNonAssociation,
   davidJones2OpenNonAssociations,
-  nonAssociation,
+  mockNonAssociation,
 } from '../../server/data/testData/nonAssociationsApi'
 import { davidJones, fredMills } from '../../server/data/testData/offenderSearch'
+
+/**
+ * TODO: THIS ENTIRE API IS A WORK-IN-PROGRESS
+ */
 
 export default {
   stubNonAssociationsApiPing: (): SuperAgentRequest => {
@@ -54,16 +58,44 @@ export default {
     })
   },
 
-  stubAddNonAssociation: () => {
+  stubGetNonAssociation: () => {
+    return stubFor({
+      request: {
+        method: 'GET',
+        urlPattern: '/non-associations/\\d+',
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: mockNonAssociation(davidJones.prisonerNumber, fredMills.prisonerNumber),
+      },
+    })
+  },
+
+  stubCreateNonAssociation: () => {
     return stubFor({
       request: {
         method: 'POST',
         urlPattern: '/non-associations',
       },
       response: {
+        status: 201,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: mockNonAssociation(davidJones.prisonerNumber, fredMills.prisonerNumber),
+      },
+    })
+  },
+
+  stubUpdateNonAssociation: () => {
+    return stubFor({
+      request: {
+        method: 'PATCH',
+        urlPattern: '/non-associations/\\d+',
+      },
+      response: {
         status: 200,
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
-        jsonBody: nonAssociation(davidJones.prisonerNumber, fredMills.prisonerNumber),
+        jsonBody: mockNonAssociation(davidJones.prisonerNumber, fredMills.prisonerNumber),
       },
     })
   },

--- a/server/data/nonAssociationsApi.ts
+++ b/server/data/nonAssociationsApi.ts
@@ -40,35 +40,46 @@ export interface NonAssociationsList {
   prisonId: string
   prisonName: string
   cellLocation: string
-  nonAssociations: {
-    id: number
-    roleCode: keyof Role
-    roleDescription: Role[keyof Role]
-    reasonCode: keyof Reason
-    reasonDescription: Reason[keyof Reason]
-    restrictionTypeCode: keyof RestrictionType
-    restrictionTypeDescription: RestrictionType[keyof RestrictionType]
-    comment: string
-    authorisedBy: string
-    whenCreated: string
-    isClosed: boolean
-    closedBy: string | null
-    closedReason: string | null
-    closedAt: string | null
-    otherPrisonerDetails: {
-      prisonerNumber: string
+  nonAssociations: Array<
+    {
+      id: number
       roleCode: keyof Role
       roleDescription: Role[keyof Role]
-      firstName: string
-      lastName: string
-      prisonId: string
-      prisonName: string
-      cellLocation: string
-    }
-  }[]
+      reasonCode: keyof Reason
+      reasonDescription: Reason[keyof Reason]
+      restrictionTypeCode: keyof RestrictionType
+      restrictionTypeDescription: RestrictionType[keyof RestrictionType]
+      comment: string
+      authorisedBy: string
+      whenCreated: string
+      otherPrisonerDetails: {
+        prisonerNumber: string
+        roleCode: keyof Role
+        roleDescription: Role[keyof Role]
+        firstName: string
+        lastName: string
+        prisonId: string
+        prisonName: string
+        cellLocation: string
+      }
+    } & (
+      | {
+          isClosed: false
+          closedBy: null
+          closedReason: null
+          closedAt: null
+        }
+      | {
+          isClosed: true
+          closedBy: string
+          closedReason: string
+          closedAt: string
+        }
+    )
+  >
 }
 
-export interface NonAssociation {
+export type NonAssociation = {
   id: number
   firstPrisonerNumber: string
   firstPrisonerRole: keyof Role
@@ -79,11 +90,20 @@ export interface NonAssociation {
   comment: string
   authorisedBy: string
   whenCreated: string
-  isClosed: boolean
-  closedBy: string | null
-  closedReason: string | null
-  closedAt: string | null
-}
+} & (
+  | {
+      isClosed: false
+      closedBy: null
+      closedReason: null
+      closedAt: null
+    }
+  | {
+      isClosed: true
+      closedBy: string
+      closedReason: string
+      closedAt: string
+    }
+)
 
 export interface CreateNonAssociationRequest {
   firstPrisonerNumber: string

--- a/server/data/nonAssociationsApi.ts
+++ b/server/data/nonAssociationsApi.ts
@@ -111,7 +111,15 @@ export interface CreateNonAssociationRequest {
   secondPrisonerNumber: string
   secondPrisonerRole: keyof Role
   reason: keyof Reason
-  restrictionType: string
+  restrictionType: keyof RestrictionType
+  comment: string
+}
+
+export interface UpdateNonAssociationRequest {
+  firstPrisonerRole: keyof Role
+  secondPrisonerRole: keyof Role
+  reason: keyof Reason
+  restrictionType: keyof RestrictionType
   comment: string
 }
 
@@ -135,7 +143,7 @@ export class NonAssociationsApi extends RestClient {
       includeClosed = false,
       includeOtherPrisons = false,
       sortBy = 'WHEN_CREATED',
-      sortDirection = 'ASC',
+      sortDirection = 'DESC',
     }: {
       includeClosed?: boolean
       includeOtherPrisons?: boolean
@@ -155,11 +163,28 @@ export class NonAssociationsApi extends RestClient {
   }
 
   /**
+   * Retrieve a non-association by ID
+   */
+  getNonAssociation(id: number): Promise<NonAssociation> {
+    return this.get({ path: `/non-associations/${encodeURIComponent(id)}` })
+  }
+
+  /**
    * Create a new non-association
    */
   createNonAssociation(request: CreateNonAssociationRequest): Promise<NonAssociation> {
     return this.post<NonAssociation>({
       path: '/non-associations',
+      data: request as unknown as Record<string, unknown>,
+    })
+  }
+
+  /**
+   * Update an existing new non-association
+   */
+  updateNonAssociation(id: number, request: UpdateNonAssociationRequest): Promise<NonAssociation> {
+    return this.patch<NonAssociation>({
+      path: `/non-associations/${encodeURIComponent(id)}`,
       data: request as unknown as Record<string, unknown>,
     })
   }

--- a/server/data/offenderSearch.ts
+++ b/server/data/offenderSearch.ts
@@ -3,6 +3,7 @@ import RestClient from './restClient'
 
 export type OffenderSearchResult = {
   prisonId: string
+  prisonName: string
   bookingId: number
   prisonerNumber: string
   firstName: string

--- a/server/data/testData/nonAssociationsApi.ts
+++ b/server/data/testData/nonAssociationsApi.ts
@@ -1,59 +1,100 @@
-import type { LegacyNonAssociationsList } from '../nonAssociationsApi'
+import type { NonAssociationsList, NonAssociation } from '../nonAssociationsApi'
+import { davidJones, fredMills, oscarJones } from './offenderSearch'
 
-// TODO: this is incomplete
-export const sampleEmptyLegacyNonAssociation: LegacyNonAssociationsList = {
-  offenderNo: 'G6123VU',
-  firstName: 'JOHN',
-  lastName: 'G6123VU',
+/**
+ * TODO: THIS ENTIRE API IS A WORK-IN-PROGRESS
+ */
+
+export const davidJones0NonAssociations: NonAssociationsList = {
+  prisonId: davidJones.prisonId,
+  prisonName: davidJones.prisonName,
+  prisonerNumber: davidJones.prisonerNumber,
+  firstName: davidJones.firstName,
+  lastName: davidJones.lastName,
+  cellLocation: davidJones.cellLocation,
   nonAssociations: [],
 }
 
-// TODO: this is incomplete
-export const sampleSingleLegacyNonAssociation: LegacyNonAssociationsList = {
-  ...sampleEmptyLegacyNonAssociation,
+export const davidJones1OpenNonAssociation: NonAssociationsList = {
+  ...davidJones0NonAssociations,
   nonAssociations: [
     {
-      reasonCode: '?????',
-      reasonDescription: '?????',
-      typeCode: '?????',
-      typeDescription: '?????',
-      offenderNonAssociation: {
-        offenderNo: 'G5992UH',
-        firstName: 'FLEM',
-        lastName: 'HERMOSILLA',
+      id: 101,
+      roleCode: 'PERPETRATOR',
+      roleDescription: 'Perpetrator',
+      reasonCode: 'VIOLENCE',
+      reasonDescription: 'Violence',
+      restrictionTypeCode: 'LANDING',
+      restrictionTypeDescription: 'Cell and landing',
+      comment: 'See IR 12133111',
+      authorisedBy: 'abc12a',
+      whenCreated: '2023-07-26T12:34:56.123456',
+      isClosed: false,
+      closedBy: null,
+      closedReason: null,
+      closedAt: null,
+      otherPrisonerDetails: {
+        prisonId: fredMills.prisonId,
+        prisonName: fredMills.prisonName,
+        prisonerNumber: fredMills.prisonerNumber,
+        firstName: fredMills.firstName,
+        lastName: fredMills.lastName,
+        roleCode: 'VICTIM',
+        roleDescription: 'Victim',
+        cellLocation: fredMills.cellLocation,
       },
-      comments: '?????',
     },
   ],
 }
 
-// TODO: this is incomplete
-export const sampleMultipleLegacyNonAssociation: LegacyNonAssociationsList = {
-  ...sampleEmptyLegacyNonAssociation,
+export const davidJones2OpenNonAssociations: NonAssociationsList = {
+  ...davidJones0NonAssociations,
   nonAssociations: [
+    davidJones1OpenNonAssociation.nonAssociations[0],
     {
-      reasonCode: '?????',
-      reasonDescription: '?????',
-      typeCode: '?????',
-      typeDescription: '?????',
-      offenderNonAssociation: {
-        offenderNo: 'G5992UH',
-        firstName: 'FLEM',
-        lastName: 'HERMOSILLA',
+      id: 102,
+      roleCode: 'NOT_RELEVANT',
+      roleDescription: 'Not relevant',
+      reasonCode: 'LEGAL_REQUEST',
+      reasonDescription: 'Police or legal request',
+      restrictionTypeCode: 'CELL',
+      restrictionTypeDescription: 'Cell only',
+      comment: 'Pending court case',
+      authorisedBy: 'cde87s',
+      whenCreated: '2023-07-21T08:14:21.123456',
+      isClosed: false,
+      closedBy: null,
+      closedReason: null,
+      closedAt: null,
+      otherPrisonerDetails: {
+        prisonId: oscarJones.prisonId,
+        prisonName: oscarJones.prisonName,
+        prisonerNumber: oscarJones.prisonerNumber,
+        firstName: oscarJones.firstName,
+        lastName: oscarJones.lastName,
+        roleCode: 'NOT_RELEVANT',
+        roleDescription: 'Not relevant',
+        cellLocation: oscarJones.cellLocation,
       },
-      comments: '?????',
-    },
-    {
-      reasonCode: '?????',
-      reasonDescription: '?????',
-      typeCode: '?????',
-      typeDescription: '?????',
-      offenderNonAssociation: {
-        offenderNo: 'G5992UH',
-        firstName: 'FLEM',
-        lastName: 'HERMOSILLA',
-      },
-      comments: '?????',
     },
   ],
+}
+
+export function nonAssociation(prisonerNumber: string, otherPrisonerNumber: string, open = true): NonAssociation {
+  return {
+    id: 101,
+    firstPrisonerNumber: prisonerNumber,
+    firstPrisonerRole: 'PERPETRATOR',
+    secondPrisonerNumber: otherPrisonerNumber,
+    secondPrisonerRole: 'VICTIM',
+    reason: 'THREAT',
+    restrictionType: 'CELL',
+    comment: 'See IR 12133100',
+    authorisedBy: 'cde87s',
+    whenCreated: '2023-07-21T08:14:21.123456',
+    isClosed: !open,
+    closedBy: open ? null : 'abc12a',
+    closedReason: open ? null : 'Problem solved',
+    closedAt: open ? null : '2023-07-26T12:34:56.123456',
+  }
 }

--- a/server/data/testData/nonAssociationsApi.ts
+++ b/server/data/testData/nonAssociationsApi.ts
@@ -80,7 +80,7 @@ export const davidJones2OpenNonAssociations: NonAssociationsList = {
   ],
 }
 
-export function nonAssociation(prisonerNumber: string, otherPrisonerNumber: string, open = true): NonAssociation {
+export function mockNonAssociation(prisonerNumber: string, otherPrisonerNumber: string, open = true): NonAssociation {
   const data: Omit<NonAssociation, 'isClosed' | 'closedBy' | 'closedReason' | 'closedAt'> = {
     id: 101,
     firstPrisonerNumber: prisonerNumber,

--- a/server/data/testData/nonAssociationsApi.ts
+++ b/server/data/testData/nonAssociationsApi.ts
@@ -81,7 +81,7 @@ export const davidJones2OpenNonAssociations: NonAssociationsList = {
 }
 
 export function nonAssociation(prisonerNumber: string, otherPrisonerNumber: string, open = true): NonAssociation {
-  return {
+  const data: Omit<NonAssociation, 'isClosed' | 'closedBy' | 'closedReason' | 'closedAt'> = {
     id: 101,
     firstPrisonerNumber: prisonerNumber,
     firstPrisonerRole: 'PERPETRATOR',
@@ -92,9 +92,21 @@ export function nonAssociation(prisonerNumber: string, otherPrisonerNumber: stri
     comment: 'See IR 12133100',
     authorisedBy: 'cde87s',
     whenCreated: '2023-07-21T08:14:21.123456',
-    isClosed: !open,
-    closedBy: open ? null : 'abc12a',
-    closedReason: open ? null : 'Problem solved',
-    closedAt: open ? null : '2023-07-26T12:34:56.123456',
+  }
+  if (open) {
+    return {
+      ...data,
+      isClosed: false,
+      closedBy: null,
+      closedReason: null,
+      closedAt: null,
+    }
+  }
+  return {
+    ...data,
+    isClosed: true,
+    closedBy: 'abc12a',
+    closedReason: 'Problem solved',
+    closedAt: '2023-07-26T12:34:56.123456',
   }
 }

--- a/server/data/testData/nonAssociationsApi.ts
+++ b/server/data/testData/nonAssociationsApi.ts
@@ -28,7 +28,8 @@ export const davidJones1OpenNonAssociation: NonAssociationsList = {
       restrictionTypeDescription: 'Cell and landing',
       comment: 'See IR 12133111',
       authorisedBy: 'abc12a',
-      whenCreated: '2023-07-26T12:34:56.123456',
+      whenCreated: new Date('2023-07-26T12:34:56'),
+      whenUpdated: new Date('2023-07-26T12:34:56'),
       isClosed: false,
       closedBy: null,
       closedReason: null,
@@ -61,7 +62,8 @@ export const davidJones2OpenNonAssociations: NonAssociationsList = {
       restrictionTypeDescription: 'Cell only',
       comment: 'Pending court case',
       authorisedBy: 'cde87s',
-      whenCreated: '2023-07-21T08:14:21.123456',
+      whenCreated: new Date('2023-07-21T08:14:21'),
+      whenUpdated: new Date('2023-07-21T08:14:21'),
       isClosed: false,
       closedBy: null,
       closedReason: null,
@@ -91,7 +93,8 @@ export function mockNonAssociation(prisonerNumber: string, otherPrisonerNumber: 
     restrictionType: 'CELL',
     comment: 'See IR 12133100',
     authorisedBy: 'cde87s',
-    whenCreated: '2023-07-21T08:14:21.123456',
+    whenCreated: new Date('2023-07-21T08:14:21'),
+    whenUpdated: new Date('2023-07-21T08:14:21'),
   }
   if (open) {
     return {
@@ -107,6 +110,6 @@ export function mockNonAssociation(prisonerNumber: string, otherPrisonerNumber: 
     isClosed: true,
     closedBy: 'abc12a',
     closedReason: 'Problem solved',
-    closedAt: '2023-07-26T12:34:56.123456',
+    closedAt: new Date('2023-07-26T12:34:56'),
   }
 }

--- a/server/data/testData/offenderSearch.ts
+++ b/server/data/testData/offenderSearch.ts
@@ -2,6 +2,7 @@ import type { OffenderSearchResult, OffenderSearchResults } from '../offenderSea
 
 export const davidJones: OffenderSearchResult = {
   prisonId: 'MDI',
+  prisonName: 'Moorland (HMP)',
   bookingId: 12345,
   prisonerNumber: 'A1234BC',
   firstName: 'DAVID',
@@ -11,6 +12,7 @@ export const davidJones: OffenderSearchResult = {
 
 export const fredMills: OffenderSearchResult = {
   prisonId: 'MDI',
+  prisonName: 'Moorland (HMP)',
   bookingId: 12346,
   prisonerNumber: 'A1235EF',
   firstName: 'FRED',
@@ -20,6 +22,7 @@ export const fredMills: OffenderSearchResult = {
 
 export const oscarJones: OffenderSearchResult = {
   prisonId: 'MDI',
+  prisonName: 'Moorland (HMP)',
   bookingId: 12347,
   prisonerNumber: 'A1236CS',
   firstName: 'OSCAR',

--- a/server/forms/add.test.ts
+++ b/server/forms/add.test.ts
@@ -1,4 +1,5 @@
-import AddForm, { type AddData, roleOptions, reasonOptions, restrictionTypeOptions } from './add'
+import { roleOptions, reasonOptions, restrictionTypeOptions } from '../data/nonAssociationsApi'
+import AddForm, { type AddData } from './add'
 
 describe('AddForm', () => {
   it('should present errors when the payload is empty', () => {

--- a/server/forms/add.ts
+++ b/server/forms/add.ts
@@ -1,33 +1,7 @@
 import format from '../utils/format'
+import type { Reason, RestrictionType, Role } from '../data/nonAssociationsApi'
+import { roleOptions, reasonOptions, restrictionTypeOptions, maxCommentLength } from '../data/nonAssociationsApi'
 import { BaseForm } from './index'
-
-export const roleOptions = {
-  VICTIM: 'Victim',
-  PERPETRATOR: 'Perpetrator',
-  NOT_RELEVANT: 'Not relevant',
-  UNKNOWN: 'Unknown',
-} as const
-export type Role = typeof roleOptions
-
-export const reasonOptions = {
-  BULLYING: 'Bullying',
-  GANG_RELATED: 'Gang related',
-  ORGANISED_CRIME: 'Organised crime',
-  LEGAL_REQUEST: 'Police or legal request',
-  THREAT: 'Threat',
-  VIOLENCE: 'Violence',
-  OTHER: 'Other',
-} as const
-export type Reason = typeof reasonOptions
-
-export const restrictionTypeOptions = {
-  CELL: 'Cell only',
-  LANDING: 'Cell and landing',
-  WING: 'Cell, landing and wing',
-}
-export type RestrictionType = typeof restrictionTypeOptions
-
-export const maxCommentLength = 240 as const
 
 export type AddData = {
   prisonerRole: keyof Role

--- a/server/routes/add.ts
+++ b/server/routes/add.ts
@@ -5,12 +5,13 @@ import logger from '../../logger'
 import { nameOfPrisoner, reversedNameOfPrisoner } from '../utils/utils'
 import asyncMiddleware from '../middleware/asyncMiddleware'
 import HmppsAuthClient from '../data/hmppsAuthClient'
+import { roleOptions, reasonOptions, restrictionTypeOptions, maxCommentLength } from '../data/nonAssociationsApi'
 import { OffenderSearchClient } from '../data/offenderSearch'
 import { createRedisClient } from '../data/redisClient'
 import TokenStore from '../data/tokenStore'
 import type { Services } from '../services'
 import formPostRoute from './forms/post'
-import AddForm, { roleOptions, reasonOptions, restrictionTypeOptions, maxCommentLength } from '../forms/add'
+import AddForm from '../forms/add'
 
 const hmppsAuthClient = new HmppsAuthClient(new TokenStore(createRedisClient()))
 


### PR DESCRIPTION
Currently supports listing, adding, updating and closing non-associations.

Depends on [api#42](https://github.com/ministryofjustice/hmpps-non-associations-api/pull/42)