### PR TITLE
NON-145: Prevent editing of closed non-associations

### DIFF
--- a/server/routes/update.test.ts
+++ b/server/routes/update.test.ts
@@ -84,6 +84,23 @@ describe('Update non-association page', () => {
       })
   })
 
+  it('should return 404 if the non-association is closed', () => {
+    const closedNonAssociation = mockNonAssociation(prisoner.prisonerNumber, otherPrisoner.prisonerNumber, false)
+
+    nonAssociationsApi.getNonAssociation.mockResolvedValueOnce(closedNonAssociation)
+    offenderSearchClient.getPrisoner.mockResolvedValueOnce(prisoner)
+    offenderSearchClient.getPrisoner.mockResolvedValueOnce(otherPrisoner)
+
+    return request(app)
+      .get(routeUrls.update(prisonerNumber, closedNonAssociation.id))
+      .expect(404)
+      .expect('Content-Type', /html/)
+      .expect(res => {
+        expect(res.text).not.toContain('Jones, David')
+        expect(nonAssociationsApi.getNonAssociation).toHaveBeenCalledTimes(1)
+      })
+  })
+
   it('should render breadcrumbs', () => {
     nonAssociationsApi.getNonAssociation.mockResolvedValueOnce(nonAssociation)
     offenderSearchClient.getPrisoner.mockResolvedValueOnce(prisoner)

--- a/server/routes/update.ts
+++ b/server/routes/update.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express'
+import { NotFound } from 'http-errors'
 
 import logger from '../../logger'
 import { nameOfPerson, reversedNameOfPerson } from '../utils/utils'
@@ -38,6 +39,10 @@ export default function updateRoutes(service: Services): Router {
         const offenderSearchClient = new OffenderSearchClient(systemToken)
         const nonAssociationsApi = new NonAssociationsApi(res.locals.user.token)
         const nonAssociation = await nonAssociationsApi.getNonAssociation(nonAssociationId)
+
+        if (nonAssociation.isClosed) {
+          throw NotFound(`Non-association ${nonAssociationId} is closed and can't be edited`)
+        }
 
         const prisoner = await offenderSearchClient.getPrisoner(prisonerNumber)
         const prisonerName = nameOfPerson(prisoner)


### PR DESCRIPTION
Once non-associations are closed can't be edited directly by the user.

Route returns 404 to indicate the page to edit a closed non-association doesn't "exist".