### PR TITLE
Rename close request fields to match api changes

### DIFF
--- a/integration_tests/pages/nonAssociations/closePrisonerDetails.ts
+++ b/integration_tests/pages/nonAssociations/closePrisonerDetails.ts
@@ -2,11 +2,11 @@ import Page, { type PageElement } from '../page'
 
 export default class ClosePrisonerDetails extends Page {
   constructor() {
-    super(`Close a non-association`)
+    super('Close a non-association')
   }
 
   getCloseCommentBox(): PageElement<HTMLElement> {
-    return cy.get('#close-closureReason')
+    return cy.get('#close-closedReason')
   }
 
   getCloseButton(): PageElement<HTMLElement> {

--- a/server/data/nonAssociationsApi.ts
+++ b/server/data/nonAssociationsApi.ts
@@ -142,9 +142,9 @@ export interface UpdateNonAssociationRequest {
 }
 
 export interface CloseNonAssociationRequest {
-  closureReason: string
-  dateOfClosure?: Date
-  staffMemberRequestingClosure?: string
+  closedReason: string
+  closedAt?: Date
+  closedBy?: string
 }
 
 export const sortByOptions = ['WHEN_CREATED', 'WHEN_UPDATED', 'LAST_NAME', 'FIRST_NAME', 'PRISONER_NUMBER'] as const

--- a/server/forms/close.test.ts
+++ b/server/forms/close.test.ts
@@ -5,57 +5,57 @@ describe('CloseForm', () => {
     const form = new CloseForm()
     form.submit({})
     expect(form.hasErrors).toBeTruthy()
-    expect(form.fields.closureReason.error).toBeTruthy()
+    expect(form.fields.closedReason.error).toBeTruthy()
   })
 
   it('should present errors when comment is empty', () => {
     const form = new CloseForm()
-    form.submit({ closureReason: '' })
+    form.submit({ closedReason: '' })
     expect(form.hasErrors).toBeTruthy()
-    expect(form.fields.closureReason.error).toBeTruthy()
+    expect(form.fields.closedReason.error).toBeTruthy()
   })
 
   it('should accept valid payload', () => {
-    const validPayload: CloseData = { closureReason: 'Problem resolved' }
+    const validPayload: CloseData = { closedReason: 'Problem resolved' }
     const form = new CloseForm()
     form.submit(validPayload)
     expect(form.hasErrors).toBeFalsy()
-    expect(form.fields.closureReason.error).toBeFalsy()
-    expect(form.fields.closureReason.value).toEqual('Problem resolved')
+    expect(form.fields.closedReason.error).toBeFalsy()
+    expect(form.fields.closedReason.value).toEqual('Problem resolved')
   })
 
   it('should trim whitespace from comment', () => {
-    const validPayload: CloseData = { closureReason: 'Problem resolved  ' }
+    const validPayload: CloseData = { closedReason: 'Problem resolved  ' }
     const form = new CloseForm()
     form.submit(validPayload)
     expect(form.hasErrors).toBeFalsy()
-    expect(form.fields.closureReason.error).toBeFalsy()
-    expect(form.fields.closureReason.value).toEqual('Problem resolved')
+    expect(form.fields.closedReason.error).toBeFalsy()
+    expect(form.fields.closedReason.value).toEqual('Problem resolved')
   })
 
   describe('should handle long comments', () => {
     it('by allowing 240 characters', () => {
-      const closureReason = '0'.repeat(240)
+      const closedReason = '0'.repeat(240)
       const form = new CloseForm()
-      form.submit({ closureReason })
+      form.submit({ closedReason })
       expect(form.hasErrors).toBeFalsy()
-      expect(form.fields.closureReason.value).toEqual(closureReason)
+      expect(form.fields.closedReason.value).toEqual(closedReason)
     })
 
     it('by allowing 240 characters if the rest is whitespace', () => {
-      const closureReason = '0'.repeat(240)
+      const closedReason = '0'.repeat(240)
       const form = new CloseForm()
-      form.submit({ closureReason: `${closureReason}  ` })
+      form.submit({ closedReason: `${closedReason}  ` })
       expect(form.hasErrors).toBeFalsy()
-      expect(form.fields.closureReason.value).toEqual(closureReason)
+      expect(form.fields.closedReason.value).toEqual(closedReason)
     })
 
     it('by disallowing more than 240 characters', () => {
-      const closureReason = '0'.repeat(241)
+      const closedReason = '0'.repeat(241)
       const form = new CloseForm()
-      form.submit({ closureReason })
+      form.submit({ closedReason })
       expect(form.hasErrors).toBeTruthy()
-      expect(form.fields.closureReason.error).toEqual('Comment must be 240 characters or less')
+      expect(form.fields.closedReason.error).toEqual('Comment must be 240 characters or less')
     })
   })
 })

--- a/server/forms/close.ts
+++ b/server/forms/close.ts
@@ -2,17 +2,17 @@ import { BaseForm } from './index'
 import { maxCommentLength } from '../data/nonAssociationsApi'
 
 export type CloseData = {
-  closureReason: string
+  closedReason: string
 }
 
 export default class CloseForm extends BaseForm<CloseData> {
   protected validate(): void {
-    if (!this.data.closureReason || /^\s*$/.test(this.data.closureReason)) {
-      this.addError('closureReason', 'Enter a comment')
+    if (!this.data.closedReason || /^\s*$/.test(this.data.closedReason)) {
+      this.addError('closedReason', 'Enter a comment')
     } else {
-      this.data.closureReason = this.data.closureReason.trim()
-      if (this.data.closureReason.length > maxCommentLength) {
-        this.addError('closureReason', `Comment must be ${maxCommentLength} characters or less`)
+      this.data.closedReason = this.data.closedReason.trim()
+      if (this.data.closedReason.length > maxCommentLength) {
+        this.addError('closedReason', `Comment must be ${maxCommentLength} characters or less`)
       }
     }
   }

--- a/server/routes/close.test.ts
+++ b/server/routes/close.test.ts
@@ -161,7 +161,7 @@ describe('Close non-association page', () => {
       .post(routeUrls.close(prisonerNumber, openNonAssociation.id))
       .send({
         formId: 'close',
-        closureReason: '',
+        closedReason: '',
       })
       .expect(200)
       .expect('Content-Type', /html/)
@@ -185,7 +185,7 @@ describe('Close non-association page', () => {
       .post(routeUrls.close(prisonerNumber, openNonAssociation.id))
       .send({
         formId: 'close',
-        closureReason: 'Problem resolved through mediation',
+        closedReason: 'Problem resolved through mediation',
       })
       .expect(200)
       .expect('Content-Type', /html/)
@@ -193,7 +193,7 @@ describe('Close non-association page', () => {
         expect(offenderSearchClient.getPrisoner).toHaveBeenCalledTimes(2)
         expect(nonAssociationsApi.closeNonAssociation).toHaveBeenCalledTimes(1)
         expect(nonAssociationsApi.closeNonAssociation).toHaveBeenCalledWith(openNonAssociation.id, {
-          closureReason: 'Problem resolved through mediation',
+          closedReason: 'Problem resolved through mediation',
         })
 
         expect(res.text).toContain('The non-association has been closed')
@@ -219,7 +219,7 @@ describe('Close non-association page', () => {
       .post(routeUrls.close(prisonerNumber, openNonAssociation.id))
       .send({
         formId: 'close',
-        closureReason: 'Problem resolved through mediation',
+        closedReason: 'Problem resolved through mediation',
       })
       .expect(200)
       .expect('Content-Type', /html/)

--- a/server/routes/close.ts
+++ b/server/routes/close.ts
@@ -61,7 +61,7 @@ export default function addRoutes(service: Services): Router {
       const form: CloseForm = res.locals.forms[formId]
       if (form.submitted && !form.hasErrors) {
         const request: CloseNonAssociationRequest = {
-          closureReason: form.fields.closureReason.value,
+          closedReason: form.fields.closedReason.value,
         }
         try {
           const response = await api.closeNonAssociation(nonAssociationId, request)

--- a/server/views/pages/close.njk
+++ b/server/views/pages/close.njk
@@ -28,7 +28,7 @@
       </p>
 
       <form method="post" novalidate>
-        {% set fieldId = "closureReason" %}
+        {% set fieldId = "closedReason" %}
         {% set field = form.fields[fieldId] %}
         {{ govukCharacterCount({
           id: formId + "-" + fieldId,


### PR DESCRIPTION
Depends on [api#66](https://github.com/ministryofjustice/hmpps-non-associations-api/pull/66)