### PR TITLE
NON-193: Non-associations list page

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
           key: dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: Get wiremock
-          command: curl -o wiremock.jar https://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-standalone/2.27.1/wiremock-standalone-2.27.1.jar
+          command: curl -o wiremock.jar https://repo1.maven.org/maven2/com/github/tomakehurst/wiremock-jre8-standalone/2.35.0/wiremock-jre8-standalone-2.35.0.jar
       - run:
           name: Run wiremock
           command: java -jar wiremock.jar --port 9091

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,10 @@ parameters:
     type: string
     default: 18.17-browsers
 
+  cypress-videos:
+    type: string
+    default: 'false'
+
 jobs:
   build:
     executor:
@@ -97,13 +101,15 @@ jobs:
           command: sleep 5
       - run:
           name: Run integration tests
-          command: npm run int-test
+          command: npm run int-test -- --config video=<< pipeline.parameters.cypress-videos >>
       - store_test_results:
           path: test_results
       - store_artifacts:
-          path: integration-tests/videos
+          name: 'Uploading cypress videos'
+          path: integration_tests/videos
       - store_artifacts:
-          path: integration-tests/screenshots
+          name: 'Uploading cypress screenshots'
+          path: integration_tests/screenshots
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,7 +53,7 @@ jobs:
             - node_modules
             - build
             - dist
-            - .cache/Cypress
+            - assets/stylesheets
 
   unit_test:
     executor:

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -39,6 +39,7 @@
         "@typescript-eslint/no-use-before-define": 0,
         "class-methods-use-this": 0,
         "no-useless-constructor": 0,
+        "quotes": ["error", "single", { "avoidEscape": true, "allowTemplateLiterals": false }],
         "@typescript-eslint/no-unused-vars": [
           1,
           {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -111,6 +111,7 @@
       }
     ],
     "no-use-before-define": 0,
+    "no-restricted-syntax": ["error", "ForInStatement", "LabeledStatement", "WithStatement"],
     "no-shadow": "off",
     "@typescript-eslint/no-shadow": ["error"],
     "semi": 0,

--- a/assets/scss/application.scss
+++ b/assets/scss/application.scss
@@ -14,6 +14,7 @@ $govuk-page-width: $moj-page-width;
 @import './components/error-pages';
 @import './components/field-and-button-group';
 @import './components/header';
+@import './components/key-prisoner-details';
 @import './components/pagination';
 @import './components/prisoner-photo';
 @import './components/sortable-table';

--- a/assets/scss/components/_key-prisoner-details.scss
+++ b/assets/scss/components/_key-prisoner-details.scss
@@ -1,0 +1,35 @@
+.app-key-prisoner-details {
+  @extend .govuk-\!-padding-4;
+  display: flex;
+  flex-direction: row;
+  align-items: start;
+  background: govuk-colour("light-grey");
+
+  .app-prisoner-photo--small {
+    margin-right: 50px;
+  }
+
+  dl {
+    margin-right: 80px;
+
+    &:last-child {
+      margin-right: 0;
+    }
+  }
+
+  .app-key-prisoner-details--align-right {
+    margin-left: auto;
+  }
+
+  @include govuk-media-query($until: tablet) {
+    display: block;
+
+    .app-prisoner-photo--small {
+      margin-bottom: govuk-spacing(4);
+    }
+
+    dl {
+      margin-right: 0;
+    }
+  }
+}

--- a/assets/scss/page/_list.scss
+++ b/assets/scss/page/_list.scss
@@ -22,10 +22,6 @@
   width: 21%;
 }
 
-.app-list__cell--comment--wide {
-  width: 31%;
-}
-
 .app-list__cell--date-updated {
   width: 13%;
 }

--- a/assets/scss/page/_view.scss
+++ b/assets/scss/page/_view.scss
@@ -1,36 +1,6 @@
-.app-view__key-prisoner-details {
-  @extend .govuk-\!-padding-4;
-  display: flex;
-  align-items: start;
-  background: govuk-colour("light-grey");
-
-  .app-prisoner-photo--small {
-    margin-right: 50px;
-  }
-
-  dl {
-    margin-right: 80px;
-
-    &:last-child {
-      margin-right: 0;
-    }
-  }
-
-  @include govuk-media-query($until: tablet) {
-    display: block;
-
-    .app-prisoner-photo--small {
-      margin-bottom: govuk-spacing(4);
-    }
-
-    dl {
-      margin-right: 0;
-    }
-  }
-}
-
 .app-view__other-prisoner-details {
   display: flex;
+  flex-direction: row;
   align-items: start;
 
   .app-prisoner-photo--large {

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -17,8 +17,11 @@ export default defineConfig({
   reporterOptions: {
     configFile: 'reporter-config.json',
   },
+  video: false,
   videoUploadOnPasses: false,
   taskTimeout: 60000,
+  viewportWidth: 1200,
+  viewportHeight: 850,
   e2e: {
     setupNodeEvents(on) {
       on('task', {

--- a/integration_tests/e2e/add.cy.ts
+++ b/integration_tests/e2e/add.cy.ts
@@ -48,7 +48,7 @@ context('Add non-association page', () => {
     addDetailsPage.getRadioButtonReason('Threat').click()
     addDetailsPage.getRadioButtonRestrictionType('Cell only').click()
     addDetailsPage.getAddCommentBox().type('Andrew is a bully')
-    addDetailsPage.getSaveButton().click()
+    addDetailsPage.saveButton.click()
 
     Page.verifyOnPage(AddConfirmationPage)
   })

--- a/integration_tests/e2e/add.cy.ts
+++ b/integration_tests/e2e/add.cy.ts
@@ -13,6 +13,7 @@ context('Add non-association page', () => {
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
     cy.task('stubNomisUserCaseloads')
+    cy.task('stubPrisonApiGetPhoto')
     cy.task('stubOffenderSearchGetPrisoner')
     cy.task('stubListNonAssociations')
     cy.signIn()

--- a/integration_tests/e2e/add.cy.ts
+++ b/integration_tests/e2e/add.cy.ts
@@ -13,7 +13,7 @@ context('Add non-association page', () => {
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
     cy.task('stubNomisUserCaseloads')
-    cy.task('stubOffenderSearchGetPrisonerResult', { prisonerNumber: davidJones.prisonerNumber, result: davidJones })
+    cy.task('stubOffenderSearchGetPrisoner')
     cy.task('stubListNonAssociations')
     cy.signIn()
 
@@ -32,7 +32,6 @@ context('Add non-association page', () => {
       term: 'Andrew',
       results: [andrewBrown],
     })
-    cy.task('stubOffenderSearchGetPrisonerResult', { prisonerNumber: andrewBrown.prisonerNumber, result: andrewBrown })
 
     listPage.addButton.click()
     const prisonerSearchPage = Page.verifyOnPage(PrisonerSearchPage)

--- a/integration_tests/e2e/add.cy.ts
+++ b/integration_tests/e2e/add.cy.ts
@@ -47,7 +47,7 @@ context('Add non-association page', () => {
     addDetailsPage.getRadioButtonOtherPrisonerRole('Victim').click()
     addDetailsPage.getRadioButtonReason('Threat').click()
     addDetailsPage.getRadioButtonRestrictionType('Cell only').click()
-    addDetailsPage.getAddCommentBox().type('Andrew is a bully')
+    addDetailsPage.commentBox.type('Andrew is a bully')
     addDetailsPage.saveButton.click()
 
     Page.verifyOnPage(AddConfirmationPage)

--- a/integration_tests/e2e/add.cy.ts
+++ b/integration_tests/e2e/add.cy.ts
@@ -43,10 +43,10 @@ context('Add non-association page', () => {
     cy.task('stubCreateNonAssociation')
 
     const addDetailsPage = Page.verifyOnPage(AddPage)
-    addDetailsPage.radioButtonPrisonerRole.click()
-    addDetailsPage.radioButtonOtherPrisonerRole.click()
-    addDetailsPage.radioButtonReason.click()
-    addDetailsPage.radioButtonRestrictionType.click()
+    addDetailsPage.getRadioButtonForPrisonerRole('Perpetrator').click()
+    addDetailsPage.getRadioButtonOtherPrisonerRole('Victim').click()
+    addDetailsPage.getRadioButtonReason('Threat').click()
+    addDetailsPage.getRadioButtonRestrictionType('Cell only').click()
     addDetailsPage.getAddCommentBox().type('Andrew is a bully')
     addDetailsPage.getSaveButton().click()
 

--- a/integration_tests/e2e/add.cy.ts
+++ b/integration_tests/e2e/add.cy.ts
@@ -1,12 +1,12 @@
 import { davidJones, andrewBrown } from '../../server/data/testData/offenderSearch'
 import Page from '../pages/page'
-import AddPrisonerSearch from '../pages/nonAssociations/addPrisonerSearch'
-import AddPrisonerDetails from '../pages/nonAssociations/addPrisonerDetails'
-import AddPrisonerConfirmation from '../pages/nonAssociations/addPrisonerConfirmation'
-import ListPrisonerNonAssociations from '../pages/nonAssociations/listPrisonerNonAssociations'
+import AddPage from '../pages/nonAssociations/add'
+import AddConfirmationPage from '../pages/nonAssociations/addConfirmation'
+import ListPage from '../pages/nonAssociations/list'
+import PrisonerSearchPage from '../pages/nonAssociations/prisonerSearch'
 
-context('Add prisoner non associations page', () => {
-  let listPage: ListPrisonerNonAssociations
+context('Add non-association page', () => {
+  let listPage: ListPage
 
   beforeEach(() => {
     cy.task('reset')
@@ -18,15 +18,15 @@ context('Add prisoner non associations page', () => {
     cy.signIn()
 
     cy.visit(`/prisoner/${davidJones.prisonerNumber}/non-associations`)
-    listPage = Page.verifyOnPage(ListPrisonerNonAssociations, 'David Jones’')
+    listPage = Page.verifyOnPage(ListPage, 'David Jones’')
   })
 
-  it('navigate to add non association', () => {
+  it('navigate to add non-association', () => {
     listPage.addButton.click()
     cy.title().should('eq', 'Search for a prisoner')
   })
 
-  it('should allow adding a new non association', () => {
+  it('should allow adding a new non-association', () => {
     cy.task('stubOffenderSearchResults', {
       prisonId: 'MDI',
       term: 'Andrew',
@@ -35,14 +35,14 @@ context('Add prisoner non associations page', () => {
     cy.task('stubOffenderSearchGetPrisonerResult', { prisonerNumber: andrewBrown.prisonerNumber, result: andrewBrown })
 
     listPage.addButton.click()
-    const prisonerSearchPage = Page.verifyOnPage(AddPrisonerSearch)
+    const prisonerSearchPage = Page.verifyOnPage(PrisonerSearchPage)
     prisonerSearchPage.getInputField().type('Andrew')
     prisonerSearchPage.getSearchButton().click()
     prisonerSearchPage.getSelectPrisonerLink().click()
 
     cy.task('stubCreateNonAssociation')
 
-    const addDetailsPage = Page.verifyOnPage(AddPrisonerDetails)
+    const addDetailsPage = Page.verifyOnPage(AddPage)
     addDetailsPage.radioButtonPrisonerRole.click()
     addDetailsPage.radioButtonOtherPrisonerRole.click()
     addDetailsPage.radioButtonReason.click()
@@ -50,6 +50,6 @@ context('Add prisoner non associations page', () => {
     addDetailsPage.getAddCommentBox().type('Andrew is a bully')
     addDetailsPage.getSaveButton().click()
 
-    Page.verifyOnPage(AddPrisonerConfirmation)
+    Page.verifyOnPage(AddConfirmationPage)
   })
 })

--- a/integration_tests/e2e/add.cy.ts
+++ b/integration_tests/e2e/add.cy.ts
@@ -1,25 +1,17 @@
-import { davidJones, andrewBrown } from '../../server/data/testData/offenderSearch'
+import { andrewBrown } from '../../server/data/testData/offenderSearch'
 import Page from '../pages/page'
 import AddPage from '../pages/nonAssociations/add'
 import AddConfirmationPage from '../pages/nonAssociations/addConfirmation'
 import ListPage from '../pages/nonAssociations/list'
 import PrisonerSearchPage from '../pages/nonAssociations/prisonerSearch'
+import { resetBasicStubs, navigateToDavidJonesNonAssociations } from './index'
 
 context('Add non-association page', () => {
   let listPage: ListPage
 
   beforeEach(() => {
-    cy.task('reset')
-    cy.task('stubSignIn')
-    cy.task('stubAuthUser')
-    cy.task('stubNomisUserCaseloads')
-    cy.task('stubPrisonApiGetPhoto')
-    cy.task('stubOffenderSearchGetPrisoner')
-    cy.task('stubListNonAssociations')
-    cy.signIn()
-
-    cy.visit(`/prisoner/${davidJones.prisonerNumber}/non-associations`)
-    listPage = Page.verifyOnPage(ListPage, 'David Jones’')
+    resetBasicStubs()
+    listPage = navigateToDavidJonesNonAssociations()
   })
 
   it('navigate to add non-association', () => {

--- a/integration_tests/e2e/add.cy.ts
+++ b/integration_tests/e2e/add.cy.ts
@@ -27,7 +27,10 @@ context('Add non-association page', () => {
     })
 
     listPage.addButton.click()
+
     const prisonerSearchPage = Page.verifyOnPage(PrisonerSearchPage)
+    prisonerSearchPage.checkLastBreadcrumb('Non-associations')
+
     prisonerSearchPage.getInputField().type('Andrew')
     prisonerSearchPage.getSearchButton().click()
     prisonerSearchPage.getSelectPrisonerLink().click()
@@ -35,6 +38,8 @@ context('Add non-association page', () => {
     cy.task('stubCreateNonAssociation')
 
     const addDetailsPage = Page.verifyOnPage(AddPage)
+    addDetailsPage.checkLastBreadcrumb('Non-associations')
+
     addDetailsPage.getRadioButtonForPrisonerRole('Perpetrator').click()
     addDetailsPage.getRadioButtonOtherPrisonerRole('Victim').click()
     addDetailsPage.getRadioButtonReason('Threat').click()

--- a/integration_tests/e2e/addPrisonerNonAssociation.cy.ts
+++ b/integration_tests/e2e/addPrisonerNonAssociation.cy.ts
@@ -6,21 +6,24 @@ import AddPrisonerConfirmation from '../pages/nonAssociations/addPrisonerConfirm
 import ListPrisonerNonAssociations from '../pages/nonAssociations/listPrisonerNonAssociations'
 
 context('Add prisoner non associations page', () => {
+  let listPage: ListPrisonerNonAssociations
+
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
     cy.task('stubNomisUserCaseloads')
-    cy.task('stubOffenderSearchGetPrisonerResult', { prisonerNumber: 'A1234BC', result: davidJones })
+    cy.task('stubOffenderSearchGetPrisonerResult', { prisonerNumber: davidJones.prisonerNumber, result: davidJones })
     cy.task('stubListNonAssociations')
     cy.signIn()
-    cy.visit('/prisoner/A1234BC/non-associations')
+
+    cy.visit(`/prisoner/${davidJones.prisonerNumber}/non-associations`)
+    listPage = Page.verifyOnPage(ListPrisonerNonAssociations, 'David Jones’')
   })
 
   it('navigate to add non association', () => {
-    const homePage = Page.verifyOnPage(ListPrisonerNonAssociations)
-    homePage.getAddNewNonAssociation().click()
-    cy.title().should('eq', `Search for a prisoner`)
+    listPage.addButton.click()
+    cy.title().should('eq', 'Search for a prisoner')
   })
 
   it('should allow adding a new non association', () => {
@@ -29,17 +32,16 @@ context('Add prisoner non associations page', () => {
       term: 'Andrew',
       results: [andrewBrown],
     })
+    cy.task('stubOffenderSearchGetPrisonerResult', { prisonerNumber: andrewBrown.prisonerNumber, result: andrewBrown })
 
-    const homePage = Page.verifyOnPage(ListPrisonerNonAssociations)
-    homePage.getAddNewNonAssociation().click()
-    cy.task('stubOffenderSearchGetPrisonerResult', { prisonerNumber: 'A5678CS', result: andrewBrown })
-
-    const addPage = Page.verifyOnPage(AddPrisonerSearch)
-    addPage.getInputField().type('Andrew')
-    addPage.getSearchButton().click()
-    addPage.getSelectPrisonerLink().click()
+    listPage.addButton.click()
+    const prisonerSearchPage = Page.verifyOnPage(AddPrisonerSearch)
+    prisonerSearchPage.getInputField().type('Andrew')
+    prisonerSearchPage.getSearchButton().click()
+    prisonerSearchPage.getSelectPrisonerLink().click()
 
     cy.task('stubCreateNonAssociation')
+
     const addDetailsPage = Page.verifyOnPage(AddPrisonerDetails)
     addDetailsPage.radioButtonPrisonerRole.click()
     addDetailsPage.radioButtonOtherPrisonerRole.click()

--- a/integration_tests/e2e/close.cy.ts
+++ b/integration_tests/e2e/close.cy.ts
@@ -23,6 +23,8 @@ context('Close prisoner non-association page', () => {
     cy.task('stubCloseNonAssociation')
 
     const closePage = Page.verifyOnPage(ClosePage)
+    closePage.checkLastBreadcrumb('Non-associations')
+
     closePage.getCloseCommentBox().type('They are now friends')
     closePage.getCloseButton().click()
 

--- a/integration_tests/e2e/close.cy.ts
+++ b/integration_tests/e2e/close.cy.ts
@@ -13,6 +13,7 @@ context('Close prisoner non-association page', () => {
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
     cy.task('stubNomisUserCaseloads')
+    cy.task('stubPrisonApiGetPhoto')
     cy.task('stubOffenderSearchGetPrisoner')
     cy.task('stubListNonAssociations')
     cy.signIn()

--- a/integration_tests/e2e/close.cy.ts
+++ b/integration_tests/e2e/close.cy.ts
@@ -1,12 +1,12 @@
 import { davidJones, fredMills } from '../../server/data/testData/offenderSearch'
 import Page from '../pages/page'
-import ClosePrisonerDetails from '../pages/nonAssociations/closePrisonerDetails'
-import ClosePrisonerConfirmation from '../pages/nonAssociations/closePrisonerConfirmation'
-import ListPrisonerNonAssociations from '../pages/nonAssociations/listPrisonerNonAssociations'
-import ViewNonAssociation from '../pages/nonAssociations/viewNonAssociation'
+import ClosePage from '../pages/nonAssociations/close'
+import CloseConfirmationPage from '../pages/nonAssociations/closeConfirmation'
+import ListPage from '../pages/nonAssociations/list'
+import ViewPage from '../pages/nonAssociations/view'
 
-context('Close prisoner non associations page', () => {
-  let listPage: ListPrisonerNonAssociations
+context('Close prisoner non-association page', () => {
+  let listPage: ListPage
 
   beforeEach(() => {
     cy.task('reset')
@@ -18,23 +18,23 @@ context('Close prisoner non associations page', () => {
     cy.signIn()
 
     cy.visit(`/prisoner/${davidJones.prisonerNumber}/non-associations`)
-    listPage = Page.verifyOnPage(ListPrisonerNonAssociations, 'David Jones’')
+    listPage = Page.verifyOnPage(ListPage, 'David Jones’')
   })
 
-  it('should allow closing a non association ', () => {
+  it('should allow closing a non-association', () => {
     cy.task('stubOffenderSearchGetPrisonerResult', { prisonerNumber: fredMills.prisonerNumber, result: fredMills })
     cy.task('stubGetNonAssociation')
 
     listPage.getViewLinkForRow(0).click()
-    const viewPage = Page.verifyOnPage(ViewNonAssociation, 'David Jones', 'Fred Mills')
+    const viewPage = Page.verifyOnPage(ViewPage, 'David Jones', 'Fred Mills')
     viewPage.closeButton.click()
 
     cy.task('stubCloseNonAssociation')
 
-    const closePage = Page.verifyOnPage(ClosePrisonerDetails)
+    const closePage = Page.verifyOnPage(ClosePage)
     closePage.getCloseCommentBox().type('They are now friends')
     closePage.getCloseButton().click()
 
-    Page.verifyOnPage(ClosePrisonerConfirmation)
+    Page.verifyOnPage(CloseConfirmationPage)
   })
 })

--- a/integration_tests/e2e/close.cy.ts
+++ b/integration_tests/e2e/close.cy.ts
@@ -1,25 +1,16 @@
-import { davidJones } from '../../server/data/testData/offenderSearch'
 import Page from '../pages/page'
 import ClosePage from '../pages/nonAssociations/close'
 import CloseConfirmationPage from '../pages/nonAssociations/closeConfirmation'
 import ListPage from '../pages/nonAssociations/list'
 import ViewPage from '../pages/nonAssociations/view'
+import { resetBasicStubs, navigateToDavidJonesNonAssociations } from './index'
 
 context('Close prisoner non-association page', () => {
   let listPage: ListPage
 
   beforeEach(() => {
-    cy.task('reset')
-    cy.task('stubSignIn')
-    cy.task('stubAuthUser')
-    cy.task('stubNomisUserCaseloads')
-    cy.task('stubPrisonApiGetPhoto')
-    cy.task('stubOffenderSearchGetPrisoner')
-    cy.task('stubListNonAssociations')
-    cy.signIn()
-
-    cy.visit(`/prisoner/${davidJones.prisonerNumber}/non-associations`)
-    listPage = Page.verifyOnPage(ListPage, 'David Jones’')
+    resetBasicStubs()
+    listPage = navigateToDavidJonesNonAssociations()
   })
 
   it('should allow closing a non-association', () => {

--- a/integration_tests/e2e/close.cy.ts
+++ b/integration_tests/e2e/close.cy.ts
@@ -1,4 +1,4 @@
-import { davidJones, fredMills } from '../../server/data/testData/offenderSearch'
+import { davidJones } from '../../server/data/testData/offenderSearch'
 import Page from '../pages/page'
 import ClosePage from '../pages/nonAssociations/close'
 import CloseConfirmationPage from '../pages/nonAssociations/closeConfirmation'
@@ -13,7 +13,7 @@ context('Close prisoner non-association page', () => {
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
     cy.task('stubNomisUserCaseloads')
-    cy.task('stubOffenderSearchGetPrisonerResult', { prisonerNumber: davidJones.prisonerNumber, result: davidJones })
+    cy.task('stubOffenderSearchGetPrisoner')
     cy.task('stubListNonAssociations')
     cy.signIn()
 
@@ -22,7 +22,6 @@ context('Close prisoner non-association page', () => {
   })
 
   it('should allow closing a non-association', () => {
-    cy.task('stubOffenderSearchGetPrisonerResult', { prisonerNumber: fredMills.prisonerNumber, result: fredMills })
     cy.task('stubGetNonAssociation')
 
     listPage.getViewLinkForRow(0).click()

--- a/integration_tests/e2e/closePrisonerNonAssociation.cy.ts
+++ b/integration_tests/e2e/closePrisonerNonAssociation.cy.ts
@@ -3,25 +3,32 @@ import Page from '../pages/page'
 import ClosePrisonerDetails from '../pages/nonAssociations/closePrisonerDetails'
 import ClosePrisonerConfirmation from '../pages/nonAssociations/closePrisonerConfirmation'
 import ListPrisonerNonAssociations from '../pages/nonAssociations/listPrisonerNonAssociations'
+import ViewNonAssociation from '../pages/nonAssociations/viewNonAssociation'
 
 context('Close prisoner non associations page', () => {
+  let listPage: ListPrisonerNonAssociations
+
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
     cy.task('stubNomisUserCaseloads')
-    cy.task('stubOffenderSearchGetPrisonerResult', { prisonerNumber: 'A1234BC', result: davidJones })
+    cy.task('stubOffenderSearchGetPrisonerResult', { prisonerNumber: davidJones.prisonerNumber, result: davidJones })
     cy.task('stubListNonAssociations')
     cy.signIn()
-    cy.visit('/prisoner/A1234BC/non-associations')
+
+    cy.visit(`/prisoner/${davidJones.prisonerNumber}/non-associations`)
+    listPage = Page.verifyOnPage(ListPrisonerNonAssociations, 'David Jones’')
   })
 
   it('should allow closing a non association ', () => {
-    cy.task('stubOffenderSearchGetPrisonerResult', { prisonerNumber: 'A1235EF', result: fredMills })
-    cy.task('stubGetNonAssociationForClose')
+    cy.task('stubOffenderSearchGetPrisonerResult', { prisonerNumber: fredMills.prisonerNumber, result: fredMills })
+    cy.task('stubGetNonAssociation')
 
-    const homePage = Page.verifyOnPage(ListPrisonerNonAssociations)
-    homePage.getCloseNonAssociation().click()
+    listPage.getViewLinkForRow(0).click()
+    const viewPage = Page.verifyOnPage(ViewNonAssociation, 'David Jones', 'Fred Mills')
+    viewPage.closeButton.click()
+
     cy.task('stubCloseNonAssociation')
 
     const closePage = Page.verifyOnPage(ClosePrisonerDetails)

--- a/integration_tests/e2e/index.cy.ts
+++ b/integration_tests/e2e/index.cy.ts
@@ -1,12 +1,10 @@
 import Page from '../pages/page'
 import IndexPage from '../pages/index'
+import { resetBasicStubs } from './index'
 
 context('Index page', () => {
   beforeEach(() => {
-    cy.task('reset')
-    cy.task('stubSignIn')
-    cy.task('stubAuthUser')
-    cy.task('stubNomisUserCaseloads')
+    resetBasicStubs()
   })
 
   it('should show expected header and footer elements', () => {

--- a/integration_tests/e2e/index.ts
+++ b/integration_tests/e2e/index.ts
@@ -1,0 +1,29 @@
+import { davidJones } from '../../server/data/testData/offenderSearch'
+import Page from '../pages/page'
+import ListPage from '../pages/nonAssociations/list'
+
+/**
+ * Set up stubs needed for all interactions
+ */
+export function resetBasicStubs(): void {
+  cy.task('reset')
+  cy.task('stubSignIn')
+  cy.task('stubAuthUser')
+  cy.task('stubNomisUserCaseloads')
+}
+
+/**
+ * Set up stubs needed for listing non-associations for David Jones
+ * and navigate to list page
+ */
+export function navigateToDavidJonesNonAssociations(): ListPage {
+  cy.signIn()
+
+  cy.task('stubPrisonApiGetPhoto')
+  cy.task('stubPrisonApiGetStaffDetails')
+  cy.task('stubOffenderSearchGetPrisoner')
+  cy.task('stubListNonAssociations')
+
+  cy.visit(`/prisoner/${davidJones.prisonerNumber}/non-associations`)
+  return Page.verifyOnPage(ListPage, 'David Jones’')
+}

--- a/integration_tests/e2e/list.cy.ts
+++ b/integration_tests/e2e/list.cy.ts
@@ -1,23 +1,13 @@
 import { davidJones, fredMills, oscarJones } from '../../server/data/testData/offenderSearch'
-import Page from '../pages/page'
 import ListPage from '../pages/nonAssociations/list'
+import { resetBasicStubs, navigateToDavidJonesNonAssociations } from './index'
 
 context('List non-associations page', () => {
   let listPage: ListPage
 
   beforeEach(() => {
-    cy.task('reset')
-    cy.task('stubSignIn')
-    cy.task('stubAuthUser')
-    cy.task('stubNomisUserCaseloads')
-    cy.task('stubPrisonApiGetPhoto')
-    cy.task('stubPrisonApiGetStaffDetails')
-    cy.task('stubOffenderSearchGetPrisoner')
-    cy.task('stubListNonAssociations')
-    cy.signIn()
-
-    cy.visit(`/prisoner/${davidJones.prisonerNumber}/non-associations`)
-    listPage = Page.verifyOnPage(ListPage, 'David Jones’')
+    resetBasicStubs()
+    listPage = navigateToDavidJonesNonAssociations()
   })
 
   it('has correct title', () => {

--- a/integration_tests/e2e/list.cy.ts
+++ b/integration_tests/e2e/list.cy.ts
@@ -1,9 +1,9 @@
 import { davidJones } from '../../server/data/testData/offenderSearch'
 import Page from '../pages/page'
-import ListPrisonerNonAssociations from '../pages/nonAssociations/listPrisonerNonAssociations'
+import ListPage from '../pages/nonAssociations/list'
 
-context('Prisoner non associations Page', () => {
-  let listPage: ListPrisonerNonAssociations
+context('List non-associations page', () => {
+  let listPage: ListPage
 
   beforeEach(() => {
     cy.task('reset')
@@ -15,7 +15,7 @@ context('Prisoner non associations Page', () => {
     cy.signIn()
 
     cy.visit(`/prisoner/${davidJones.prisonerNumber}/non-associations`)
-    listPage = Page.verifyOnPage(ListPrisonerNonAssociations, 'David Jones’')
+    listPage = Page.verifyOnPage(ListPage, 'David Jones’')
   })
 
   it('has correct title', () => {

--- a/integration_tests/e2e/list.cy.ts
+++ b/integration_tests/e2e/list.cy.ts
@@ -1,4 +1,4 @@
-import { davidJones } from '../../server/data/testData/offenderSearch'
+import { davidJones, fredMills, oscarJones } from '../../server/data/testData/offenderSearch'
 import Page from '../pages/page'
 import ListPage from '../pages/nonAssociations/list'
 
@@ -10,6 +10,8 @@ context('List non-associations page', () => {
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
     cy.task('stubNomisUserCaseloads')
+    cy.task('stubPrisonApiGetPhoto')
+    cy.task('stubPrisonApiGetStaffDetails')
     cy.task('stubOffenderSearchGetPrisoner')
     cy.task('stubListNonAssociations')
     cy.signIn()
@@ -30,8 +32,39 @@ context('List non-associations page', () => {
     listPage.addButton.should('exist')
   })
 
+  it('should show key prisoner’s details', () => {
+    listPage.keyPrisonerBox.should('contain.text', 'Jones, David')
+    listPage.keyPrisonerBox.should('contain.text', davidJones.prisonerNumber)
+    listPage.keyPrisonerBox.should('contain.text', davidJones.cellLocation)
+  })
+
   it('should have open tab selected', () => {
     listPage.openTab.should('have.class', 'govuk-tabs__list-item--selected')
+  })
+
+  it('should show a table of open non-associations', () => {
+    listPage.tableRowContents.then(rows => {
+      expect(rows).to.have.length(2)
+      const [fredMillsRow, oscarJonesRow] = rows
+
+      expect(fredMillsRow[1]).to.contain(fredMills.prisonerNumber)
+      expect(fredMillsRow[1]).to.contain('Mills, Fred')
+      expect(fredMillsRow[2]).to.contain('Violence')
+      expect(fredMillsRow[3]).to.contain('Victim')
+      expect(fredMillsRow[4]).to.contain('Cell and landing')
+      expect(fredMillsRow[5]).to.contain('IR 12133111')
+      expect(fredMillsRow[6]).to.contain('26 July 2023')
+      expect(fredMillsRow[6]).to.contain('Mary Johnson')
+
+      expect(oscarJonesRow[1]).to.contain(oscarJones.prisonerNumber)
+      expect(oscarJonesRow[1]).to.contain('Jones, Oscar')
+      expect(oscarJonesRow[2]).to.contain('Police')
+      expect(oscarJonesRow[3]).to.contain('Not relevant')
+      expect(oscarJonesRow[4]).to.contain('Cell only')
+      expect(oscarJonesRow[5]).to.contain('Pending court case')
+      expect(oscarJonesRow[6]).to.contain('21 July 2023')
+      expect(oscarJonesRow[6]).to.contain('Mark Simmons')
+    })
   })
 
   it('should display the closed tab', () => {

--- a/integration_tests/e2e/list.cy.ts
+++ b/integration_tests/e2e/list.cy.ts
@@ -21,7 +21,7 @@ context('List non-associations page', () => {
   })
 
   it('has correct title', () => {
-    cy.title().should('eq', `David Jones’ non-associations`)
+    cy.title().should('eq', 'David Jones’ non-associations')
   })
 
   it('has correct breadcrumb', () => {

--- a/integration_tests/e2e/list.cy.ts
+++ b/integration_tests/e2e/list.cy.ts
@@ -10,7 +10,7 @@ context('List non-associations page', () => {
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
     cy.task('stubNomisUserCaseloads')
-    cy.task('stubOffenderSearchGetPrisonerResult', { prisonerNumber: davidJones.prisonerNumber, result: davidJones })
+    cy.task('stubOffenderSearchGetPrisoner')
     cy.task('stubListNonAssociations')
     cy.signIn()
 

--- a/integration_tests/e2e/listPrisonerNonAssociations.cy.ts
+++ b/integration_tests/e2e/listPrisonerNonAssociations.cy.ts
@@ -3,30 +3,40 @@ import Page from '../pages/page'
 import ListPrisonerNonAssociations from '../pages/nonAssociations/listPrisonerNonAssociations'
 
 context('Prisoner non associations Page', () => {
+  let listPage: ListPrisonerNonAssociations
+
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
     cy.task('stubNomisUserCaseloads')
-    cy.task('stubOffenderSearchGetPrisonerResult', { prisonerNumber: 'A1234BC', result: davidJones })
+    cy.task('stubOffenderSearchGetPrisonerResult', { prisonerNumber: davidJones.prisonerNumber, result: davidJones })
     cy.task('stubListNonAssociations')
     cy.signIn()
-    cy.visit('/prisoner/A1234BC/non-associations')
+
+    cy.visit(`/prisoner/${davidJones.prisonerNumber}/non-associations`)
+    listPage = Page.verifyOnPage(ListPrisonerNonAssociations, 'David Jones’')
   })
+
   it('has correct title', () => {
     cy.title().should('eq', `David Jones’ non-associations`)
   })
 
   it('has correct breadcrumb', () => {
-    const homePage = Page.verifyOnPage(ListPrisonerNonAssociations)
-    homePage.checkLastBreadcrumb('Jones, David')
+    listPage.checkLastBreadcrumb('Jones, David')
+  })
+
+  it('has add button', () => {
+    listPage.addButton.should('exist')
+  })
+
+  it('should have open tab selected', () => {
+    listPage.openTab.should('have.class', 'govuk-tabs__list-item--selected')
   })
 
   it('should display the closed tab', () => {
-    const homePage = Page.verifyOnPage(ListPrisonerNonAssociations)
-    homePage.getClosedNonAssociations().click()
-    homePage
-      .getClosedNonAssociationsParent()
-      .should('have.class', 'govuk-tabs__list-item govuk-tabs__list-item--selected')
+    listPage.closedTab.should('not.have.class', 'govuk-tabs__list-item--selected')
+    listPage.closedTab.find('a').click()
+    listPage.closedTab.should('have.class', 'govuk-tabs__list-item--selected')
   })
 })

--- a/integration_tests/e2e/login.cy.ts
+++ b/integration_tests/e2e/login.cy.ts
@@ -2,13 +2,11 @@ import Page from '../pages/page'
 import IndexPage from '../pages/index'
 import AuthSignInPage from '../pages/authSignIn'
 import AuthManageDetailsPage from '../pages/authManageDetails'
+import { resetBasicStubs } from './index'
 
 context('SignIn', () => {
   beforeEach(() => {
-    cy.task('reset')
-    cy.task('stubSignIn')
-    cy.task('stubAuthUser')
-    cy.task('stubNomisUserCaseloads')
+    resetBasicStubs()
   })
 
   it('Unauthenticated user directed to auth', () => {

--- a/integration_tests/e2e/update.cy.ts
+++ b/integration_tests/e2e/update.cy.ts
@@ -1,25 +1,16 @@
-import { davidJones } from '../../server/data/testData/offenderSearch'
 import Page from '../pages/page'
 import ListPage from '../pages/nonAssociations/list'
 import ViewPage from '../pages/nonAssociations/view'
 import UpdatePage from '../pages/nonAssociations/update'
 import UpdateConfirmationPage from '../pages/nonAssociations/updateConfirmation'
+import { resetBasicStubs, navigateToDavidJonesNonAssociations } from './index'
 
 context('Update prisoner non-association page', () => {
   let listPage: ListPage
 
   beforeEach(() => {
-    cy.task('reset')
-    cy.task('stubSignIn')
-    cy.task('stubAuthUser')
-    cy.task('stubNomisUserCaseloads')
-    cy.task('stubPrisonApiGetPhoto')
-    cy.task('stubOffenderSearchGetPrisoner')
-    cy.task('stubListNonAssociations')
-    cy.signIn()
-
-    cy.visit(`/prisoner/${davidJones.prisonerNumber}/non-associations`)
-    listPage = Page.verifyOnPage(ListPage, 'David Jones’')
+    resetBasicStubs()
+    listPage = navigateToDavidJonesNonAssociations()
   })
 
   it('should allow updating a non-association', () => {

--- a/integration_tests/e2e/update.cy.ts
+++ b/integration_tests/e2e/update.cy.ts
@@ -33,7 +33,7 @@ context('Update prisoner non-association page', () => {
 
     const updatePage = Page.verifyOnPage(UpdatePage)
     updatePage.getUpdateCommentBox().type(' and IR456456')
-    updatePage.getUpdateButton().click()
+    updatePage.saveButton.click()
 
     Page.verifyOnPage(UpdateConfirmationPage)
   })

--- a/integration_tests/e2e/update.cy.ts
+++ b/integration_tests/e2e/update.cy.ts
@@ -32,7 +32,7 @@ context('Update prisoner non-association page', () => {
     cy.task('stubUpdateNonAssociation')
 
     const updatePage = Page.verifyOnPage(UpdatePage)
-    updatePage.getUpdateCommentBox().type(' and IR456456')
+    updatePage.commentBox.type(' and IR456456')
     updatePage.saveButton.click()
 
     Page.verifyOnPage(UpdateConfirmationPage)

--- a/integration_tests/e2e/update.cy.ts
+++ b/integration_tests/e2e/update.cy.ts
@@ -1,4 +1,4 @@
-import { davidJones, fredMills } from '../../server/data/testData/offenderSearch'
+import { davidJones } from '../../server/data/testData/offenderSearch'
 import Page from '../pages/page'
 import ListPage from '../pages/nonAssociations/list'
 import ViewPage from '../pages/nonAssociations/view'
@@ -13,7 +13,7 @@ context('Update prisoner non-association page', () => {
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
     cy.task('stubNomisUserCaseloads')
-    cy.task('stubOffenderSearchGetPrisonerResult', { prisonerNumber: davidJones.prisonerNumber, result: davidJones })
+    cy.task('stubOffenderSearchGetPrisoner')
     cy.task('stubListNonAssociations')
     cy.signIn()
 
@@ -22,7 +22,6 @@ context('Update prisoner non-association page', () => {
   })
 
   it('should allow updating a non-association', () => {
-    cy.task('stubOffenderSearchGetPrisonerResult', { prisonerNumber: fredMills.prisonerNumber, result: fredMills })
     cy.task('stubGetNonAssociation')
 
     listPage.getViewLinkForRow(0).click()

--- a/integration_tests/e2e/update.cy.ts
+++ b/integration_tests/e2e/update.cy.ts
@@ -23,6 +23,8 @@ context('Update prisoner non-association page', () => {
     cy.task('stubUpdateNonAssociation')
 
     const updatePage = Page.verifyOnPage(UpdatePage)
+    updatePage.checkLastBreadcrumb('Non-associations')
+
     updatePage.commentBox.type(' and IR456456')
     updatePage.saveButton.click()
 

--- a/integration_tests/e2e/update.cy.ts
+++ b/integration_tests/e2e/update.cy.ts
@@ -13,6 +13,7 @@ context('Update prisoner non-association page', () => {
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
     cy.task('stubNomisUserCaseloads')
+    cy.task('stubPrisonApiGetPhoto')
     cy.task('stubOffenderSearchGetPrisoner')
     cy.task('stubListNonAssociations')
     cy.signIn()

--- a/integration_tests/e2e/update.cy.ts
+++ b/integration_tests/e2e/update.cy.ts
@@ -1,12 +1,12 @@
 import { davidJones, fredMills } from '../../server/data/testData/offenderSearch'
 import Page from '../pages/page'
-import ListPrisonerNonAssociations from '../pages/nonAssociations/listPrisonerNonAssociations'
-import UpdatePrisonerDetails from '../pages/nonAssociations/updatePrisonerDetails'
-import UpdatePrisonerConfirmation from '../pages/nonAssociations/updatePrisonerConfirmation'
-import ViewNonAssociation from '../pages/nonAssociations/viewNonAssociation'
+import ListPage from '../pages/nonAssociations/list'
+import ViewPage from '../pages/nonAssociations/view'
+import UpdatePage from '../pages/nonAssociations/update'
+import UpdateConfirmationPage from '../pages/nonAssociations/updateConfirmation'
 
-context('Update prisoner non associations page', () => {
-  let listPage: ListPrisonerNonAssociations
+context('Update prisoner non-association page', () => {
+  let listPage: ListPage
 
   beforeEach(() => {
     cy.task('reset')
@@ -18,23 +18,23 @@ context('Update prisoner non associations page', () => {
     cy.signIn()
 
     cy.visit(`/prisoner/${davidJones.prisonerNumber}/non-associations`)
-    listPage = Page.verifyOnPage(ListPrisonerNonAssociations, 'David Jones’')
+    listPage = Page.verifyOnPage(ListPage, 'David Jones’')
   })
 
-  it('should allow updating a non association ', () => {
+  it('should allow updating a non-association', () => {
     cy.task('stubOffenderSearchGetPrisonerResult', { prisonerNumber: fredMills.prisonerNumber, result: fredMills })
     cy.task('stubGetNonAssociation')
 
     listPage.getViewLinkForRow(0).click()
-    const viewPage = Page.verifyOnPage(ViewNonAssociation, 'David Jones', 'Fred Mills')
+    const viewPage = Page.verifyOnPage(ViewPage, 'David Jones', 'Fred Mills')
     viewPage.updateButton.click()
 
     cy.task('stubUpdateNonAssociation')
 
-    const updatePage = Page.verifyOnPage(UpdatePrisonerDetails)
+    const updatePage = Page.verifyOnPage(UpdatePage)
     updatePage.getUpdateCommentBox().type(' and IR456456')
     updatePage.getUpdateButton().click()
 
-    Page.verifyOnPage(UpdatePrisonerConfirmation)
+    Page.verifyOnPage(UpdateConfirmationPage)
   })
 })

--- a/integration_tests/e2e/updatePrisonerNonAssociation.cy.ts
+++ b/integration_tests/e2e/updatePrisonerNonAssociation.cy.ts
@@ -1,32 +1,39 @@
-import { davidJones, andrewBrown } from '../../server/data/testData/offenderSearch'
+import { davidJones, fredMills } from '../../server/data/testData/offenderSearch'
 import Page from '../pages/page'
 import ListPrisonerNonAssociations from '../pages/nonAssociations/listPrisonerNonAssociations'
 import UpdatePrisonerDetails from '../pages/nonAssociations/updatePrisonerDetails'
 import UpdatePrisonerConfirmation from '../pages/nonAssociations/updatePrisonerConfirmation'
+import ViewNonAssociation from '../pages/nonAssociations/viewNonAssociation'
 
 context('Update prisoner non associations page', () => {
+  let listPage: ListPrisonerNonAssociations
+
   beforeEach(() => {
     cy.task('reset')
     cy.task('stubSignIn')
     cy.task('stubAuthUser')
     cy.task('stubNomisUserCaseloads')
-    cy.task('stubOffenderSearchGetPrisonerResult', { prisonerNumber: 'A1234BC', result: davidJones })
+    cy.task('stubOffenderSearchGetPrisonerResult', { prisonerNumber: davidJones.prisonerNumber, result: davidJones })
     cy.task('stubListNonAssociations')
     cy.signIn()
-    cy.visit('/prisoner/A1234BC/non-associations')
+
+    cy.visit(`/prisoner/${davidJones.prisonerNumber}/non-associations`)
+    listPage = Page.verifyOnPage(ListPrisonerNonAssociations, 'David Jones’')
   })
 
   it('should allow updating a non association ', () => {
-    cy.task('stubOffenderSearchGetPrisonerResult', { prisonerNumber: 'A5678CS', result: andrewBrown })
-    cy.task('stubGetNonAssociationForUpdate')
+    cy.task('stubOffenderSearchGetPrisonerResult', { prisonerNumber: fredMills.prisonerNumber, result: fredMills })
+    cy.task('stubGetNonAssociation')
 
-    const updatePage = Page.verifyOnPage(ListPrisonerNonAssociations)
-    updatePage.getUpdateNonAssociation().click()
+    listPage.getViewLinkForRow(0).click()
+    const viewPage = Page.verifyOnPage(ViewNonAssociation, 'David Jones', 'Fred Mills')
+    viewPage.updateButton.click()
+
     cy.task('stubUpdateNonAssociation')
 
-    const closePage = Page.verifyOnPage(UpdatePrisonerDetails)
-    closePage.getUpdateCommentBox().type(' and IR456456')
-    closePage.getUpdateButton().click()
+    const updatePage = Page.verifyOnPage(UpdatePrisonerDetails)
+    updatePage.getUpdateCommentBox().type(' and IR456456')
+    updatePage.getUpdateButton().click()
 
     Page.verifyOnPage(UpdatePrisonerConfirmation)
   })

--- a/integration_tests/e2e/view.cy.ts
+++ b/integration_tests/e2e/view.cy.ts
@@ -1,0 +1,41 @@
+import Page from '../pages/page'
+import ViewPage from '../pages/nonAssociations/view'
+import { resetBasicStubs, navigateToDavidJonesNonAssociations } from './index'
+import { davidJones, fredMills } from '../../server/data/testData/offenderSearch'
+
+context('View non-association details page', () => {
+  let viewPage: ViewPage
+
+  beforeEach(() => {
+    resetBasicStubs()
+    cy.task('stubGetNonAssociation')
+
+    const listPage = navigateToDavidJonesNonAssociations()
+    listPage.getViewLinkForRow(0).click()
+    viewPage = Page.verifyOnPage(ViewPage, 'David Jones', 'Fred Mills')
+  })
+
+  it('should show key prisoner’s details', () => {
+    viewPage.keyPrisonerBox.should('contain.text', 'Jones, David')
+    viewPage.keyPrisonerBox.should('contain.text', davidJones.prisonerNumber)
+    viewPage.keyPrisonerBox.should('contain.text', davidJones.cellLocation)
+    viewPage.keyPrisonerBox.should('contain.text', 'Perpetrator')
+  })
+
+  it('should show other prisoner’s details', () => {
+    viewPage.otherPrisonerBox.should('contain.text', 'Mills, Fred')
+    viewPage.otherPrisonerBox.should('contain.text', fredMills.prisonerNumber)
+    viewPage.otherPrisonerBox.should('contain.text', fredMills.cellLocation)
+    viewPage.otherPrisonerBox.should('contain.text', 'Victim')
+    viewPage.otherPrisonerBox.should('contain.text', 'See IR 12133100')
+  })
+
+  it('has correct breadcrumb', () => {
+    viewPage.checkLastBreadcrumb('Non-associations')
+  })
+
+  it('has update & close buttons when the non-association is not closed', () => {
+    viewPage.updateButton.should('exist')
+    viewPage.closeButton.should('exist')
+  })
+})

--- a/integration_tests/mockApis/nomisUserRolesApi.ts
+++ b/integration_tests/mockApis/nomisUserRolesApi.ts
@@ -17,6 +17,9 @@ export default {
     })
   },
 
+  /**
+   * Stub the current user’s prison as HMP Moorland
+   */
   stubNomisUserCaseloads(): SuperAgentRequest {
     return stubFor({
       request: {

--- a/integration_tests/mockApis/nomisUserRolesApi.ts
+++ b/integration_tests/mockApis/nomisUserRolesApi.ts
@@ -3,7 +3,7 @@ import type { SuperAgentRequest } from 'superagent'
 import { stubFor } from './wiremock'
 
 export default {
-  stubNomisUserRolesApiPing: (): SuperAgentRequest => {
+  stubNomisUserRolesApiPing(): SuperAgentRequest {
     return stubFor({
       request: {
         method: 'GET',
@@ -17,7 +17,7 @@ export default {
     })
   },
 
-  stubNomisUserCaseloads: (): SuperAgentRequest => {
+  stubNomisUserCaseloads(): SuperAgentRequest {
     return stubFor({
       request: {
         method: 'GET',

--- a/integration_tests/mockApis/nonAssociationsApi.ts
+++ b/integration_tests/mockApis/nonAssociationsApi.ts
@@ -17,7 +17,7 @@ import { andrewBrown, davidJones, fredMills, oscarJones } from '../../server/dat
  */
 
 export default {
-  stubNonAssociationsApiPing: (): SuperAgentRequest => {
+  stubNonAssociationsApiPing(): SuperAgentRequest {
     return stubFor({
       request: {
         method: 'GET',
@@ -31,13 +31,13 @@ export default {
     })
   },
 
-  stubListNonAssociations: ({
+  stubListNonAssociations({
     prisonerNumber = davidJones.prisonerNumber,
     returning = 'twoOpen',
   }: {
     prisonerNumber?: string
     returning?: 'none' | 'oneOpen' | 'twoOpen' | 'oneClosed' | 'twoClosed'
-  } = {}): SuperAgentRequest => {
+  } = {}): SuperAgentRequest {
     let nonAssociationsList: NonAssociationsList
     if (returning === 'none') {
       nonAssociationsList = davidJones0NonAssociations
@@ -64,7 +64,7 @@ export default {
     })
   },
 
-  stubGetNonAssociation: () => {
+  stubGetNonAssociation(): SuperAgentRequest {
     return stubFor({
       request: {
         method: 'GET',
@@ -78,7 +78,7 @@ export default {
     })
   },
 
-  stubCreateNonAssociation: () => {
+  stubCreateNonAssociation(): SuperAgentRequest {
     return stubFor({
       request: {
         method: 'POST',
@@ -92,7 +92,7 @@ export default {
     })
   },
 
-  stubUpdateNonAssociation: () => {
+  stubUpdateNonAssociation(): SuperAgentRequest {
     return stubFor({
       request: {
         method: 'PATCH',
@@ -106,7 +106,7 @@ export default {
     })
   },
 
-  stubCloseNonAssociation: () => {
+  stubCloseNonAssociation(): SuperAgentRequest {
     return stubFor({
       request: {
         method: 'PUT',

--- a/integration_tests/mockApis/nonAssociationsApi.ts
+++ b/integration_tests/mockApis/nonAssociationsApi.ts
@@ -64,7 +64,7 @@ export default {
     })
   },
 
-  stubGetNonAssociationForClose: () => {
+  stubGetNonAssociation: () => {
     return stubFor({
       request: {
         method: 'GET',
@@ -74,20 +74,6 @@ export default {
         status: 200,
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
         jsonBody: mockNonAssociation(davidJones.prisonerNumber, fredMills.prisonerNumber),
-      },
-    })
-  },
-
-  stubGetNonAssociationForUpdate: () => {
-    return stubFor({
-      request: {
-        method: 'GET',
-        url: '/nonAssociationsApi/non-associations/102',
-      },
-      response: {
-        status: 200,
-        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
-        jsonBody: mockNonAssociation(davidJones.prisonerNumber, andrewBrown.prisonerNumber),
       },
     })
   },

--- a/integration_tests/mockApis/nonAssociationsApi.ts
+++ b/integration_tests/mockApis/nonAssociationsApi.ts
@@ -31,11 +31,12 @@ export default {
     })
   },
 
+  /**
+   * Stub the list of non-associations for David Jones
+   */
   stubListNonAssociations({
-    prisonerNumber = davidJones.prisonerNumber,
     returning = 'twoOpen',
   }: {
-    prisonerNumber?: string
     returning?: 'none' | 'oneOpen' | 'twoOpen' | 'oneClosed' | 'twoClosed'
   } = {}): SuperAgentRequest {
     let nonAssociationsList: NonAssociationsList
@@ -50,11 +51,11 @@ export default {
     } else if (returning === 'twoClosed') {
       nonAssociationsList = davidJones2ClosedNonAssociations
     }
-
+    const url = `/nonAssociationsApi/prisoner/${encodeURIComponent(davidJones.prisonerNumber)}/non-associations`
     return stubFor({
       request: {
         method: 'GET',
-        urlPathPattern: `/nonAssociationsApi/prisoner/${encodeURIComponent(prisonerNumber)}/non-associations`,
+        urlPathPattern: url,
       },
       response: {
         status: 200,
@@ -64,6 +65,9 @@ export default {
     })
   },
 
+  /**
+   * Stub the non-association between David Jones and Fred Mills
+   */
   stubGetNonAssociation(): SuperAgentRequest {
     return stubFor({
       request: {
@@ -78,6 +82,9 @@ export default {
     })
   },
 
+  /**
+   * Stub creating a non-association between David Jones and Andrew Brown
+   */
   stubCreateNonAssociation(): SuperAgentRequest {
     return stubFor({
       request: {
@@ -92,6 +99,9 @@ export default {
     })
   },
 
+  /**
+   * Stub updating a non-association between David Jones and Oscar Jones
+   */
   stubUpdateNonAssociation(): SuperAgentRequest {
     return stubFor({
       request: {
@@ -106,6 +116,9 @@ export default {
     })
   },
 
+  /**
+   * Stub closing a non-association between David Jones and Fred Mills
+   */
   stubCloseNonAssociation(): SuperAgentRequest {
     return stubFor({
       request: {

--- a/integration_tests/mockApis/offenderSearchApi.ts
+++ b/integration_tests/mockApis/offenderSearchApi.ts
@@ -19,7 +19,9 @@ export default {
     })
   },
 
-  /** Stubs all 4 mock prisoners */
+  /**
+   * Stub gettings details for all 4 mock prisoners
+   */
   stubOffenderSearchGetPrisoner(): Promise<unknown> {
     return Promise.all(
       [davidJones, fredMills, oscarJones, andrewBrown].map(prisoner => {
@@ -38,6 +40,9 @@ export default {
     )
   },
 
+  /**
+   * Stub searching for a prisoner
+   */
   stubOffenderSearchResults({
     prisonId,
     term,

--- a/integration_tests/mockApis/offenderSearchApi.ts
+++ b/integration_tests/mockApis/offenderSearchApi.ts
@@ -2,6 +2,7 @@ import type { SuperAgentRequest } from 'superagent'
 
 import { stubFor } from './wiremock'
 import { OffenderSearchClient, type OffenderSearchResult } from '../../server/data/offenderSearch'
+import { davidJones, fredMills, oscarJones, andrewBrown } from '../../server/data/testData/offenderSearch'
 
 export default {
   stubOffenderSearchPing(): SuperAgentRequest {
@@ -18,24 +19,23 @@ export default {
     })
   },
 
-  stubOffenderSearchGetPrisonerResult({
-    prisonerNumber,
-    result,
-  }: {
-    prisonerNumber: string
-    result: OffenderSearchResult
-  }): SuperAgentRequest {
-    return stubFor({
-      request: {
-        method: 'GET',
-        urlPattern: `/offenderSearchApi/prisoner/${encodeURIComponent(prisonerNumber)}`,
-      },
-      response: {
-        status: 200,
-        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
-        jsonBody: result,
-      },
-    })
+  /** Stubs all 4 mock prisoners */
+  stubOffenderSearchGetPrisoner(): Promise<unknown> {
+    return Promise.all(
+      [davidJones, fredMills, oscarJones, andrewBrown].map(prisoner => {
+        return stubFor({
+          request: {
+            method: 'GET',
+            urlPattern: `/offenderSearchApi/prisoner/${encodeURIComponent(prisoner.prisonerNumber)}`,
+          },
+          response: {
+            status: 200,
+            headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+            jsonBody: prisoner,
+          },
+        })
+      }),
+    )
   },
 
   stubOffenderSearchResults({

--- a/integration_tests/mockApis/prisonApi.ts
+++ b/integration_tests/mockApis/prisonApi.ts
@@ -4,10 +4,11 @@ import path from 'path'
 import type { SuperAgentRequest } from 'superagent'
 
 import applicationInfo from '../../server/applicationInfo'
+import { staffMary, staffMark, staffBarry } from '../../server/data/testData/prisonApi'
 import { stubFor } from './wiremock'
 
 export default {
-  stubPrisonApiPing: (): SuperAgentRequest => {
+  stubPrisonApiPing(): SuperAgentRequest {
     return stubFor({
       request: {
         method: 'GET',
@@ -21,7 +22,7 @@ export default {
     })
   },
 
-  stubPrisonApiGetPhoto: (): SuperAgentRequest => {
+  stubPrisonApiGetPhoto(): SuperAgentRequest {
     const imagePath = path.join(applicationInfo().packageJsonPath, 'assets', 'images', 'prisoner.jpeg')
     const imageContents = fs.readFileSync(imagePath, { encoding: 'base64' })
 
@@ -32,11 +33,28 @@ export default {
       },
       response: {
         status: 200,
-        headers: {
-          'Content-Type': 'images/jpeg',
-        },
+        headers: { 'Content-Type': 'images/jpeg' },
         base64Body: imageContents,
       },
     })
+  },
+
+  /** Stub all 3 mock staff */
+  stubPrisonApiGetStaffDetails(): Promise<unknown> {
+    return Promise.all(
+      [staffMary, staffMark, staffBarry].map(staffDetails => {
+        return stubFor({
+          request: {
+            method: 'GET',
+            url: `/prisonApi/api/users/${staffDetails.username}`,
+          },
+          response: {
+            status: 200,
+            headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+            jsonBody: staffDetails,
+          },
+        })
+      }),
+    )
   },
 }

--- a/integration_tests/mockApis/prisonApi.ts
+++ b/integration_tests/mockApis/prisonApi.ts
@@ -22,6 +22,9 @@ export default {
     })
   },
 
+  /**
+   * Use generic photo for all prisoners
+   */
   stubPrisonApiGetPhoto(): SuperAgentRequest {
     const imagePath = path.join(applicationInfo().packageJsonPath, 'assets', 'images', 'prisoner.jpeg')
     const imageContents = fs.readFileSync(imagePath, { encoding: 'base64' })
@@ -39,7 +42,9 @@ export default {
     })
   },
 
-  /** Stub all 3 mock staff */
+  /**
+   * Stub getting details of all 3 mock staff
+   */
   stubPrisonApiGetStaffDetails(): Promise<unknown> {
     return Promise.all(
       [staffMary, staffMark, staffBarry].map(staffDetails => {

--- a/integration_tests/mockApis/tokenVerification.ts
+++ b/integration_tests/mockApis/tokenVerification.ts
@@ -2,8 +2,8 @@ import type { SuperAgentRequest } from 'superagent'
 import { stubFor } from './wiremock'
 
 export default {
-  stubTokenVerificationPing: (status = 200): SuperAgentRequest =>
-    stubFor({
+  stubTokenVerificationPing(status = 200): SuperAgentRequest {
+    return stubFor({
       request: {
         method: 'GET',
         urlPattern: '/verification/health/ping',
@@ -13,9 +13,11 @@ export default {
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
         jsonBody: { status: 'UP' },
       },
-    }),
-  stubVerifyToken: (active = true): SuperAgentRequest =>
-    stubFor({
+    })
+  },
+
+  stubVerifyToken(active = true): SuperAgentRequest {
+    return stubFor({
       request: {
         method: 'POST',
         urlPattern: '/verification/token/verify',
@@ -25,5 +27,6 @@ export default {
         headers: { 'Content-Type': 'application/json;charset=UTF-8' },
         jsonBody: { active },
       },
-    }),
+    })
+  },
 }

--- a/integration_tests/mockApis/wiremock.ts
+++ b/integration_tests/mockApis/wiremock.ts
@@ -1,13 +1,11 @@
 import superagent, { type SuperAgentRequest, type Response } from 'superagent'
 
-const url = 'http://localhost:9091/__admin'
+const wiremockAdminUrl = 'http://localhost:9091/__admin'
 
-const stubFor = (mapping: Record<string, unknown>): SuperAgentRequest =>
-  superagent.post(`${url}/mappings`).send(mapping)
+export const stubFor = (mapping: Record<string, unknown>): SuperAgentRequest =>
+  superagent.post(`${wiremockAdminUrl}/mappings`).send(mapping)
 
-const getMatchingRequests = body => superagent.post(`${url}/requests/find`).send(body)
+export const getMatchingRequests = body => superagent.post(`${wiremockAdminUrl}/requests/find`).send(body)
 
-const resetStubs = (): Promise<Array<Response>> =>
-  Promise.all([superagent.delete(`${url}/mappings`), superagent.delete(`${url}/requests`)])
-
-export { stubFor, getMatchingRequests, resetStubs }
+export const resetStubs = (): Promise<Array<Response>> =>
+  Promise.all([superagent.delete(`${wiremockAdminUrl}/mappings`), superagent.delete(`${wiremockAdminUrl}/requests`)])

--- a/integration_tests/pages/nonAssociations/add.ts
+++ b/integration_tests/pages/nonAssociations/add.ts
@@ -1,28 +1,12 @@
-import Page, { type PageElement } from '../page'
+import { type PageElement } from '../page'
 
-export default class AddPage extends Page {
+import BaseAddUpdatePage from './baseAddUpdate'
+
+export default class AddPage extends BaseAddUpdatePage {
+  formId = 'add'
+
   constructor() {
     super('Non-association details')
-  }
-
-  get form(): PageElement<HTMLFormElement> {
-    return cy.get('.govuk-fieldset')
-  }
-
-  get radioButtonPrisonerRole(): PageElement<HTMLElement> {
-    return cy.get('#prisonerRole')
-  }
-
-  get radioButtonOtherPrisonerRole(): PageElement<HTMLElement> {
-    return cy.get('#otherPrisonerRole-2')
-  }
-
-  get radioButtonReason(): PageElement<HTMLElement> {
-    return cy.get('#reason')
-  }
-
-  get radioButtonRestrictionType(): PageElement<HTMLElement> {
-    return cy.get('#restrictionType')
   }
 
   getAddCommentBox(): PageElement<HTMLElement> {

--- a/integration_tests/pages/nonAssociations/add.ts
+++ b/integration_tests/pages/nonAssociations/add.ts
@@ -1,5 +1,3 @@
-import { type PageElement } from '../page'
-
 import BaseAddUpdatePage from './baseAddUpdate'
 
 export default class AddPage extends BaseAddUpdatePage {
@@ -7,9 +5,5 @@ export default class AddPage extends BaseAddUpdatePage {
 
   constructor() {
     super('Non-association details')
-  }
-
-  getAddCommentBox(): PageElement<HTMLElement> {
-    return cy.get('#add-comment')
   }
 }

--- a/integration_tests/pages/nonAssociations/add.ts
+++ b/integration_tests/pages/nonAssociations/add.ts
@@ -12,8 +12,4 @@ export default class AddPage extends BaseAddUpdatePage {
   getAddCommentBox(): PageElement<HTMLElement> {
     return cy.get('#add-comment')
   }
-
-  getSaveButton(): PageElement<HTMLElement> {
-    return cy.get('button[class="govuk-button"]')
-  }
 }

--- a/integration_tests/pages/nonAssociations/add.ts
+++ b/integration_tests/pages/nonAssociations/add.ts
@@ -1,6 +1,6 @@
 import Page, { type PageElement } from '../page'
 
-export default class AddPrisonerDetails extends Page {
+export default class AddPage extends Page {
   constructor() {
     super('Non-association details')
   }

--- a/integration_tests/pages/nonAssociations/addConfirmation.ts
+++ b/integration_tests/pages/nonAssociations/addConfirmation.ts
@@ -1,6 +1,6 @@
 import Page from '../page'
 
-export default class AddPrisonerConfirmation extends Page {
+export default class AddConfirmationPage extends Page {
   constructor() {
     super('The non-association has been added')
   }

--- a/integration_tests/pages/nonAssociations/addPrisonerConfirmation.ts
+++ b/integration_tests/pages/nonAssociations/addPrisonerConfirmation.ts
@@ -2,6 +2,6 @@ import Page from '../page'
 
 export default class AddPrisonerConfirmation extends Page {
   constructor() {
-    super(`The non-association has been added`)
+    super('The non-association has been added')
   }
 }

--- a/integration_tests/pages/nonAssociations/baseAddUpdate.ts
+++ b/integration_tests/pages/nonAssociations/baseAddUpdate.ts
@@ -41,4 +41,8 @@ export default abstract class BaseAddUpdatePage extends Page {
   ): PageElement<HTMLInputElement> {
     return this.getRadioButton('restrictionType', restrictionType)
   }
+
+  get commentBox(): PageElement<HTMLTextAreaElement> {
+    return this.form.find('.govuk-textarea')
+  }
 }

--- a/integration_tests/pages/nonAssociations/baseAddUpdate.ts
+++ b/integration_tests/pages/nonAssociations/baseAddUpdate.ts
@@ -6,14 +6,22 @@ export default abstract class BaseAddUpdatePage extends Page {
   abstract formId: string
 
   get form(): PageElement<HTMLFormElement> {
-    return cy.get('.govuk-fieldset')
+    return cy.get('form')
+  }
+
+  get saveButton(): PageElement<HTMLButtonElement> {
+    return this.form.find('.govuk-button').contains<HTMLButtonElement>('Save')
+  }
+
+  get cancelButton(): PageElement<HTMLAnchorElement> {
+    return this.form.find('.govuk-button').contains<HTMLAnchorElement>('Cancel')
   }
 
   private getRadioButton(
     name: 'prisonerRole' | 'otherPrisonerRole' | 'reason' | 'restrictionType',
     label: string,
   ): PageElement<HTMLInputElement> {
-    return cy.get(`#${this.formId}-${name}`).contains(label).prev()
+    return this.form.find(`#${this.formId}-${name}`).contains(label).prev()
   }
 
   getRadioButtonForPrisonerRole(role: Role[keyof Role]): PageElement<HTMLInputElement> {

--- a/integration_tests/pages/nonAssociations/baseAddUpdate.ts
+++ b/integration_tests/pages/nonAssociations/baseAddUpdate.ts
@@ -1,0 +1,36 @@
+import Page, { type PageElement } from '../page'
+
+import type { Role, Reason, RestrictionType } from '../../../server/data/nonAssociationsApi'
+
+export default abstract class BaseAddUpdatePage extends Page {
+  abstract formId: string
+
+  get form(): PageElement<HTMLFormElement> {
+    return cy.get('.govuk-fieldset')
+  }
+
+  private getRadioButton(
+    name: 'prisonerRole' | 'otherPrisonerRole' | 'reason' | 'restrictionType',
+    label: string,
+  ): PageElement<HTMLInputElement> {
+    return cy.get(`#${this.formId}-${name}`).contains(label).prev()
+  }
+
+  getRadioButtonForPrisonerRole(role: Role[keyof Role]): PageElement<HTMLInputElement> {
+    return this.getRadioButton('prisonerRole', role)
+  }
+
+  getRadioButtonOtherPrisonerRole(role: Role[keyof Role]): PageElement<HTMLInputElement> {
+    return this.getRadioButton('otherPrisonerRole', role)
+  }
+
+  getRadioButtonReason(reason: Reason[keyof Reason]): PageElement<HTMLInputElement> {
+    return this.getRadioButton('reason', reason)
+  }
+
+  getRadioButtonRestrictionType(
+    restrictionType: RestrictionType[keyof RestrictionType],
+  ): PageElement<HTMLInputElement> {
+    return this.getRadioButton('restrictionType', restrictionType)
+  }
+}

--- a/integration_tests/pages/nonAssociations/close.ts
+++ b/integration_tests/pages/nonAssociations/close.ts
@@ -1,6 +1,6 @@
 import Page, { type PageElement } from '../page'
 
-export default class ClosePrisonerDetails extends Page {
+export default class ClosePage extends Page {
   constructor() {
     super('Close a non-association')
   }

--- a/integration_tests/pages/nonAssociations/closeConfirmation.ts
+++ b/integration_tests/pages/nonAssociations/closeConfirmation.ts
@@ -1,6 +1,6 @@
 import Page from '../page'
 
-export default class ClosePrisonerConfirmation extends Page {
+export default class CloseConfirmationPage extends Page {
   constructor() {
     super('The non-association has been closed')
   }

--- a/integration_tests/pages/nonAssociations/closePrisonerConfirmation.ts
+++ b/integration_tests/pages/nonAssociations/closePrisonerConfirmation.ts
@@ -2,6 +2,6 @@ import Page from '../page'
 
 export default class ClosePrisonerConfirmation extends Page {
   constructor() {
-    super(`The non-association has been closed`)
+    super('The non-association has been closed')
   }
 }

--- a/integration_tests/pages/nonAssociations/list.ts
+++ b/integration_tests/pages/nonAssociations/list.ts
@@ -21,6 +21,10 @@ export default class ListPage extends Page {
     return this.tabs.eq(1)
   }
 
+  get keyPrisonerBox(): PageElement<HTMLDivElement> {
+    return cy.get('.app-key-prisoner-details')
+  }
+
   get table(): PageElement<HTMLTableElement> {
     return cy.get('.app-sortable-table')
   }
@@ -31,5 +35,20 @@ export default class ListPage extends Page {
 
   getViewLinkForRow(row: number): PageElement<HTMLAnchorElement> {
     return this.tableRows.eq(row).find('td').last().find('a')
+  }
+
+  get tableRowContents(): Cypress.Chainable<string[][]> {
+    return this.tableRows.then(bodyRows => {
+      const rows = bodyRows
+        .map((_, row) => {
+          const cells: string[] = []
+          for (let index = 0; index < row.children.length; index += 1) {
+            cells.push(row.children[index]?.textContent?.trim())
+          }
+          return { cells }
+        })
+        .toArray()
+      return cy.wrap(rows.map(({ cells }) => cells))
+    })
   }
 }

--- a/integration_tests/pages/nonAssociations/list.ts
+++ b/integration_tests/pages/nonAssociations/list.ts
@@ -1,6 +1,6 @@
 import Page, { type PageElement } from '../page'
 
-export default class ListPrisonerNonAssociations extends Page {
+export default class ListPage extends Page {
   constructor(private readonly prisonerName: string) {
     super(`${prisonerName} non-associations`)
   }

--- a/integration_tests/pages/nonAssociations/listPrisonerNonAssociations.ts
+++ b/integration_tests/pages/nonAssociations/listPrisonerNonAssociations.ts
@@ -1,31 +1,35 @@
 import Page, { type PageElement } from '../page'
 
 export default class ListPrisonerNonAssociations extends Page {
-  constructor() {
-    super(`David Jones’ non-associations`)
+  constructor(private readonly prisonerName: string) {
+    super(`${prisonerName} non-associations`)
   }
 
-  getClosedNonAssociations(): PageElement<HTMLElement> {
-    return cy.contains('Closed')
+  get addButton(): PageElement<HTMLAnchorElement> {
+    return cy.get('.govuk-button').contains<HTMLAnchorElement>('Add new non-association')
   }
 
-  getClosedNonAssociationsParent(): PageElement<HTMLElement> {
-    return cy.get('.govuk-tabs__list-item').eq(1)
+  get tabs(): PageElement<HTMLLIElement> {
+    return cy.get('.govuk-tabs__list-item')
   }
 
-  getAlphabeticallySortedNonAssociations(): PageElement<HTMLElement> {
-    return cy.contains('Prisoner details')
+  get openTab(): PageElement<HTMLLIElement> {
+    return this.tabs.eq(0)
   }
 
-  getAddNewNonAssociation(): PageElement<HTMLElement> {
-    return cy.contains('Add new non-association')
+  get closedTab(): PageElement<HTMLLIElement> {
+    return this.tabs.eq(1)
   }
 
-  getCloseNonAssociation(): PageElement<HTMLElement> {
-    return cy.get('a:contains(Close)').eq(1)
+  get table(): PageElement<HTMLTableElement> {
+    return cy.get('.app-sortable-table')
   }
 
-  getUpdateNonAssociation(): PageElement<HTMLElement> {
-    return cy.get('a:contains(Update)').eq(1)
+  get tableRows(): PageElement<HTMLTableRowElement> {
+    return this.table.find('tbody tr')
+  }
+
+  getViewLinkForRow(row: number): PageElement<HTMLAnchorElement> {
+    return this.tableRows.eq(row).find('td').last().find('a')
   }
 }

--- a/integration_tests/pages/nonAssociations/prisonerSearch.ts
+++ b/integration_tests/pages/nonAssociations/prisonerSearch.ts
@@ -2,7 +2,7 @@ import Page, { type PageElement } from '../page'
 
 export default class PrisonerSearchPage extends Page {
   constructor() {
-    super(`Search for a prisoner`)
+    super('Search for a prisoner')
   }
 
   getInputField(): PageElement<HTMLInputElement> {

--- a/integration_tests/pages/nonAssociations/prisonerSearch.ts
+++ b/integration_tests/pages/nonAssociations/prisonerSearch.ts
@@ -1,6 +1,6 @@
 import Page, { type PageElement } from '../page'
 
-export default class AddPrisonerSearch extends Page {
+export default class PrisonerSearchPage extends Page {
   constructor() {
     super(`Search for a prisoner`)
   }

--- a/integration_tests/pages/nonAssociations/update.ts
+++ b/integration_tests/pages/nonAssociations/update.ts
@@ -1,5 +1,3 @@
-import { type PageElement } from '../page'
-
 import BaseAddUpdatePage from './baseAddUpdate'
 
 export default class UpdatePage extends BaseAddUpdatePage {
@@ -7,9 +5,5 @@ export default class UpdatePage extends BaseAddUpdatePage {
 
   constructor() {
     super('Non-association details')
-  }
-
-  getUpdateCommentBox(): PageElement<HTMLElement> {
-    return cy.get('#update-comment')
   }
 }

--- a/integration_tests/pages/nonAssociations/update.ts
+++ b/integration_tests/pages/nonAssociations/update.ts
@@ -1,6 +1,6 @@
 import Page, { type PageElement } from '../page'
 
-export default class UpdatePrisonerDetails extends Page {
+export default class UpdatePage extends Page {
   constructor() {
     super(`Non-association details`)
   }

--- a/integration_tests/pages/nonAssociations/update.ts
+++ b/integration_tests/pages/nonAssociations/update.ts
@@ -2,7 +2,7 @@ import Page, { type PageElement } from '../page'
 
 export default class UpdatePage extends Page {
   constructor() {
-    super(`Non-association details`)
+    super('Non-association details')
   }
 
   getUpdateCommentBox(): PageElement<HTMLElement> {

--- a/integration_tests/pages/nonAssociations/update.ts
+++ b/integration_tests/pages/nonAssociations/update.ts
@@ -12,8 +12,4 @@ export default class UpdatePage extends BaseAddUpdatePage {
   getUpdateCommentBox(): PageElement<HTMLElement> {
     return cy.get('#update-comment')
   }
-
-  getUpdateButton(): PageElement<HTMLElement> {
-    return cy.get('button[class="govuk-button"]')
-  }
 }

--- a/integration_tests/pages/nonAssociations/update.ts
+++ b/integration_tests/pages/nonAssociations/update.ts
@@ -1,6 +1,10 @@
-import Page, { type PageElement } from '../page'
+import { type PageElement } from '../page'
 
-export default class UpdatePage extends Page {
+import BaseAddUpdatePage from './baseAddUpdate'
+
+export default class UpdatePage extends BaseAddUpdatePage {
+  formId = 'update'
+
   constructor() {
     super('Non-association details')
   }

--- a/integration_tests/pages/nonAssociations/updateConfirmation.ts
+++ b/integration_tests/pages/nonAssociations/updateConfirmation.ts
@@ -1,6 +1,6 @@
 import Page from '../page'
 
-export default class UpdatePrisonerConfirmation extends Page {
+export default class UpdateConfirmationPage extends Page {
   constructor() {
     super('The non-association has been updated')
   }

--- a/integration_tests/pages/nonAssociations/updatePrisonerConfirmation.ts
+++ b/integration_tests/pages/nonAssociations/updatePrisonerConfirmation.ts
@@ -2,6 +2,6 @@ import Page from '../page'
 
 export default class UpdatePrisonerConfirmation extends Page {
   constructor() {
-    super(`The non-association has been updated`)
+    super('The non-association has been updated')
   }
 }

--- a/integration_tests/pages/nonAssociations/view.ts
+++ b/integration_tests/pages/nonAssociations/view.ts
@@ -1,6 +1,6 @@
 import Page, { type PageElement } from '../page'
 
-export default class ViewNonAssociation extends Page {
+export default class ViewPage extends Page {
   constructor(
     private readonly prisonerName: string,
     private readonly otherPrisonerName: string,

--- a/integration_tests/pages/nonAssociations/view.ts
+++ b/integration_tests/pages/nonAssociations/view.ts
@@ -8,6 +8,14 @@ export default class ViewPage extends Page {
     super(`Non-association: ${prisonerName} and ${otherPrisonerName}`)
   }
 
+  get keyPrisonerBox(): PageElement<HTMLDivElement> {
+    return cy.get('.app-key-prisoner-details')
+  }
+
+  get otherPrisonerBox(): PageElement<HTMLDivElement> {
+    return cy.get('.app-view__other-prisoner-details')
+  }
+
   get updateButton(): PageElement<HTMLAnchorElement> {
     return cy.get('.govuk-button').contains<HTMLAnchorElement>('Update')
   }

--- a/integration_tests/pages/nonAssociations/viewNonAssociation.ts
+++ b/integration_tests/pages/nonAssociations/viewNonAssociation.ts
@@ -1,0 +1,18 @@
+import Page, { type PageElement } from '../page'
+
+export default class ViewNonAssociation extends Page {
+  constructor(
+    private readonly prisonerName: string,
+    private readonly otherPrisonerName: string,
+  ) {
+    super(`Non-association: ${prisonerName} and ${otherPrisonerName}`)
+  }
+
+  get updateButton(): PageElement<HTMLAnchorElement> {
+    return cy.get('.govuk-button').contains<HTMLAnchorElement>('Update')
+  }
+
+  get closeButton(): PageElement<HTMLAnchorElement> {
+    return cy.get('.govuk-button').contains<HTMLAnchorElement>('Close')
+  }
+}

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test": "jest",
     "test:ci": "jest --detectOpenHandles",
     "security_audit": "npx audit-ci --config audit-ci.json",
-    "int-test": "cypress run --config video=false",
+    "int-test": "cypress run",
     "int-test-ui": "cypress open",
     "clean": "rm -rf assets/stylesheets build dist node_modules"
   },

--- a/server/applicationInfo.ts
+++ b/server/applicationInfo.ts
@@ -32,7 +32,6 @@ export default (): ApplicationInfo => {
  * This function finds the application root where the package.json file resides
  */
 function findPackageJson(): string {
-  // eslint-disable-next-line no-restricted-syntax
   for (const p of [path.dirname(__dirname), path.dirname(path.dirname(__dirname))]) {
     try {
       fs.accessSync(path.join(p, 'package.json'), fs.constants.R_OK)

--- a/server/data/hmppsAuthClient.test.ts
+++ b/server/data/hmppsAuthClient.test.ts
@@ -67,7 +67,7 @@ describe('hmppsAuthClient', () => {
       tokenStore.getToken.mockResolvedValue(null)
 
       fakeHmppsAuthApi
-        .post(`/oauth/token`, 'grant_type=client_credentials&username=Bob')
+        .post('/oauth/token', 'grant_type=client_credentials&username=Bob')
         .basicAuth({ user: config.apis.hmppsAuth.systemClientId, pass: config.apis.hmppsAuth.systemClientSecret })
         .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
         .reply(200, token)
@@ -82,7 +82,7 @@ describe('hmppsAuthClient', () => {
       tokenStore.getToken.mockResolvedValue(null)
 
       fakeHmppsAuthApi
-        .post(`/oauth/token`, 'grant_type=client_credentials')
+        .post('/oauth/token', 'grant_type=client_credentials')
         .basicAuth({ user: config.apis.hmppsAuth.systemClientId, pass: config.apis.hmppsAuth.systemClientSecret })
         .matchHeader('Content-Type', 'application/x-www-form-urlencoded')
         .reply(200, token)

--- a/server/data/hmppsAuthClient.ts
+++ b/server/data/hmppsAuthClient.ts
@@ -49,7 +49,7 @@ export default class HmppsAuthClient {
   }
 
   getUser(token: string): Promise<User> {
-    logger.info(`Getting user details: calling HMPPS Auth`)
+    logger.info('Getting user details: calling HMPPS Auth')
     return HmppsAuthClient.restClient(token).get<User>({ path: '/api/user/me' })
   }
 

--- a/server/data/nomisUserRolesApi.test.ts
+++ b/server/data/nomisUserRolesApi.test.ts
@@ -24,7 +24,7 @@ describe('NomisUserRolesApi', () => {
     it('returns data from Nomis User Roles API for a user with a single caseload', async () => {
       const apiResponse = getSingleCaseload()
       nomisUserRolesApi
-        .get(`/me/caseloads`)
+        .get('/me/caseloads')
         .matchHeader('authorization', `Bearer ${accessToken}`)
         .reply(200, apiResponse)
 
@@ -38,7 +38,7 @@ describe('NomisUserRolesApi', () => {
     it('returns data from Nomis User Roles API for a user with multiple caseloads', async () => {
       const apiResponse = getMultipleCaseloads()
       nomisUserRolesApi
-        .get(`/me/caseloads`)
+        .get('/me/caseloads')
         .matchHeader('authorization', `Bearer ${accessToken}`)
         .reply(200, apiResponse)
 

--- a/server/data/restClientMetricsMiddleware.ts
+++ b/server/data/restClientMetricsMiddleware.ts
@@ -3,20 +3,20 @@ import promClient from 'prom-client'
 import { Response, SuperAgentRequest } from 'superagent'
 import UrlValueParser from 'url-value-parser'
 
-const requestHistogram = new promClient.Histogram({
+export const requestHistogram = new promClient.Histogram({
   name: 'http_client_requests_seconds',
   help: 'Timings and counts of http client requests',
   buckets: [0.5, 0.75, 0.95, 0.99, 1],
   labelNames: ['clientName', 'method', 'uri', 'status'],
 })
 
-const timeoutCounter = new promClient.Counter({
+export const timeoutCounter = new promClient.Counter({
   name: 'http_client_requests_timeout_total',
   help: 'Count of http client request timeouts',
   labelNames: ['clientName', 'method', 'uri'],
 })
 
-function restClientMetricsMiddleware(agent: SuperAgentRequest) {
+export function restClientMetricsMiddleware(agent: SuperAgentRequest) {
   agent.on('request', ({ req }) => {
     const { hostname } = new URL(agent.url)
     const normalizedPath = normalizePath(agent.url)
@@ -39,11 +39,9 @@ function restClientMetricsMiddleware(agent: SuperAgentRequest) {
   return agent
 }
 
-function normalizePath(url: string) {
+export function normalizePath(url: string) {
   const { pathname } = new URL(url)
   const urlPathReplacement = '#val'
   const urlValueParser = new UrlValueParser({ extraMasks: [/^[A-Z|0-9]+/] })
   return urlValueParser.replacePathValues(pathname, urlPathReplacement)
 }
-
-export { restClientMetricsMiddleware, normalizePath, requestHistogram, timeoutCounter }

--- a/server/data/tokenStore.ts
+++ b/server/data/tokenStore.ts
@@ -7,7 +7,7 @@ export default class TokenStore {
 
   constructor(private readonly client: RedisClient) {
     client.on('error', error => {
-      logger.error(error, `Redis error`)
+      logger.error(error, 'Redis error')
     })
   }
 

--- a/server/forms/index.test.ts
+++ b/server/forms/index.test.ts
@@ -59,7 +59,7 @@ describe('Form handling', () => {
     const form = new SimpleForm()
     form.load({ query: ' ' })
 
-    it(`it doesn't have errors`, () => {
+    it('it doesn’t have errors', () => {
       expect(form.hasErrors).toBeFalsy()
     })
 

--- a/server/index.ts
+++ b/server/index.ts
@@ -5,7 +5,5 @@ import { services } from './services'
 
 promClient.collectDefaultMetrics()
 
-const app = createApp(services())
-const metricsApp = createMetricsApp()
-
-export { app, metricsApp }
+export const app = createApp(services())
+export const metricsApp = createMetricsApp()

--- a/server/middleware/setUpWebSession.ts
+++ b/server/middleware/setUpWebSession.ts
@@ -8,7 +8,7 @@ import logger from '../../logger'
 
 export default function setUpWebSession(): Router {
   const client = createRedisClient()
-  client.connect().catch((err: Error) => logger.error(`Error connecting to Redis`, err))
+  client.connect().catch((err: Error) => logger.error('Error connecting to Redis', err))
 
   const router = express.Router()
   router.use(

--- a/server/monitoring/metricsApp.ts
+++ b/server/monitoring/metricsApp.ts
@@ -1,7 +1,7 @@
 import express from 'express'
 import promBundle from 'express-prom-bundle'
 
-const metricsMiddleware = promBundle({
+export const metricsMiddleware = promBundle({
   autoregister: false,
   buckets: [0.5, 0.75, 0.95, 0.99, 1],
   httpDurationMetricName: 'http_server_requests_seconds',
@@ -18,11 +18,9 @@ function metricsPort(): number {
   return port + 1
 }
 
-function createMetricsApp(): express.Application {
+export function createMetricsApp(): express.Application {
   const metricsApp = express()
   metricsApp.use(metricsMiddleware.metricsMiddleware)
   metricsApp.set('port', metricsPort())
   return metricsApp
 }
-
-export { metricsMiddleware, createMetricsApp }

--- a/server/routes/list.test.ts
+++ b/server/routes/list.test.ts
@@ -171,7 +171,7 @@ describe('Non-associations list page', () => {
           expect(res.text).toContain('27 July 2023')
           expect(res.text).toContain('by Mary Johnson')
           expect(res.text).toContain('by Mark Simmons')
-          expect(res.text).not.toContain('Actions')
+          expect(res.text).toContain('Actions')
           // no message
           expect(res.text).not.toContain('This prisoner has no open non-associations')
           expect(res.text).not.toContain('This prisoner has no closed non-associations')

--- a/server/routes/list.test.ts
+++ b/server/routes/list.test.ts
@@ -192,8 +192,8 @@ describe('Non-associations list page', () => {
           expect(nonAssociationsApi.listNonAssociations).toHaveBeenCalledTimes(1)
           expect(prisonApi.getStaffDetails).toHaveBeenCalledTimes(2)
 
-          expect(res.text).toContain('Open (2)')
-          expect(res.text).toContain('Closed (0)')
+          expect(res.text).toContain('Open (2 people)')
+          expect(res.text).toContain('Closed (0 people)')
         })
     })
 
@@ -209,8 +209,8 @@ describe('Non-associations list page', () => {
           expect(nonAssociationsApi.listNonAssociations).toHaveBeenCalledTimes(1)
           expect(prisonApi.getStaffDetails).toHaveBeenCalledTimes(3)
 
-          expect(res.text).toContain('Open (1)')
-          expect(res.text).toContain('Closed (2)')
+          expect(res.text).toContain('Open (1 person)')
+          expect(res.text).toContain('Closed (2 people)')
         })
     })
   })

--- a/server/routes/list.ts
+++ b/server/routes/list.ts
@@ -26,18 +26,23 @@ const tableColumns: SortableTableColumns<
     classes: 'app-list__cell--photo',
     unsortable: true,
   },
-  { column: 'LAST_NAME', escapedHtml: 'Prisoner details', classes: 'app-list__cell--prisoner' },
+  { column: 'LAST_NAME', escapedHtml: 'Name', classes: 'app-list__cell--prisoner' },
   { column: 'reason', escapedHtml: 'Reason', classes: 'app-list__cell--reason', unsortable: true },
   { column: 'role', escapedHtml: 'Role', classes: 'app-list__cell--role', unsortable: true },
   {
     column: 'restrictionType',
-    escapedHtml: 'Where to keep apart',
+    escapedHtml: 'Where to keep apart',
     classes: 'app-list__cell--restriction-type',
     unsortable: true,
   },
   { column: 'comment', escapedHtml: 'Comments', classes: 'app-list__cell--comment', unsortable: true },
   { column: 'WHEN_UPDATED', escapedHtml: 'Last updated', classes: 'app-list__cell--date-updated' },
-  { column: 'actions', escapedHtml: 'Actions', classes: 'app-list__cell--actions', unsortable: true },
+  {
+    column: 'actions',
+    escapedHtml: '<span class="govuk-visually-hidden">Actions</span>',
+    classes: 'app-list__cell--actions',
+    unsortable: true,
+  },
 ]
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/server/routes/list.ts
+++ b/server/routes/list.ts
@@ -68,7 +68,7 @@ export default function listRoutes(service: Services): Router {
       const sortBy = form.fields.sort.value
       const sortDirection = form.fields.order.value
       tableHead = sortableTableHead({
-        columns: listing === 'closed' ? tableColumns.slice(0, -1) : tableColumns,
+        columns: tableColumns,
         sortColumn: sortBy,
         order: sortDirection,
         urlPrefix: '?',

--- a/server/routes/list.ts
+++ b/server/routes/list.ts
@@ -92,6 +92,7 @@ export default function listRoutes(service: Services): Router {
     res.render('pages/list.njk', {
       messages,
       listing,
+      prisoner,
       prisonerNumber,
       prisonerName: nameOfPerson(prisoner),
       prisonName: prisoner.prisonName,

--- a/server/views/pages/authError.njk
+++ b/server/views/pages/authError.njk
@@ -3,16 +3,16 @@
 {% set pageTitle = applicationName + " – Authorisation Error" %}
 
 {% block content %}
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
 
-    <h1 class="govuk-heading-l">
-      Authorisation Error
-    </h1>
-    <p>
-      You are not authorised to use this application.
-    </p>
+      <h1 class="govuk-heading-l">
+        Authorisation Error
+      </h1>
+      <p>
+        You are not authorised to use this application.
+      </p>
 
+    </div>
   </div>
-</div>
 {% endblock %}

--- a/server/views/pages/list.njk
+++ b/server/views/pages/list.njk
@@ -3,6 +3,8 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 
+{% from "../partials/keyPrisonerDetails.njk" import keyPrisonerDetails %}
+
 {% set pageTitle = prisonerName | possessiveName + " non-associations" %}
 
 {% block content %}
@@ -13,16 +15,19 @@
   <h1 class="govuk-heading-l">
     {{ prisonerName | possessiveName}} non-associations
   </h1>
-  <p class="govuk-!-text-align-right">
-    {{ govukButton({
-      text: "Add new non-association",
-      classes: "app-button--blue",
-      element: "a",
-      href: routeUrls.prisonerSearch(prisonerNumber)
-    }) }}
-  </p>
 
-  <nav>
+  {% call keyPrisonerDetails(routeUrls, prisoner) %}
+    <div class="app-key-prisoner-details--align-right">
+      {{ govukButton({
+        text: "Add new non-association",
+        classes: "app-button--blue",
+        element: "a",
+        href: routeUrls.prisonerSearch(prisonerNumber)
+      }) }}
+    </div>
+  {% endcall %}
+
+  <nav class="govuk-!-margin-top-6">
     <ul class="govuk-tabs__list">
       <li class="govuk-tabs__list-item {% if listing === "open" %}govuk-tabs__list-item--selected{% endif %}">
         <a class="govuk-tabs__tab" href="{{ routeUrls.list(prisonerNumber) }}">

--- a/server/views/pages/list.njk
+++ b/server/views/pages/list.njk
@@ -5,6 +5,14 @@
 
 {% from "../partials/keyPrisonerDetails.njk" import keyPrisonerDetails %}
 
+{% macro peopleCount(number) %}
+  {%- if number == 1 -%}
+    1 person
+  {%- else -%}
+    {{ number }} people
+  {%- endif -%}
+{% endmacro %}
+
 {% set pageTitle = prisonerName | possessiveName + " non-associations" %}
 
 {% block content %}
@@ -31,12 +39,12 @@
     <ul class="govuk-tabs__list">
       <li class="govuk-tabs__list-item {% if listing === "open" %}govuk-tabs__list-item--selected{% endif %}">
         <a class="govuk-tabs__tab" href="{{ routeUrls.list(prisonerNumber) }}">
-          Open ({{ nonAssociationsList.openCount }})
+          Open ({{ peopleCount(nonAssociationsList.openCount) }})
         </a>
       </li>
       <li class="govuk-tabs__list-item {% if listing === "closed" %}govuk-tabs__list-item--selected{% endif %}">
         <a class="govuk-tabs__tab" href="{{ routeUrls.list(prisonerNumber, true) }}">
-          Closed ({{ nonAssociationsList.closedCount }})
+          Closed ({{ peopleCount(nonAssociationsList.closedCount) }})
         </a>
       </li>
     </ul>

--- a/server/views/pages/list.njk
+++ b/server/views/pages/list.njk
@@ -96,26 +96,19 @@
     {% endset %}
 
     {% set actions %}
-      <a href="{{ routeUrls.update(prisonerNumber, nonAssociation.id) }}">Update</a> | <br />
-      <a href="{{ routeUrls.close(prisonerNumber, nonAssociation.id) }}">Close</a>
+      <a href="{{ routeUrls.view(prisonerNumber, nonAssociation.id) }}">View details</a>
     {% endset %}
 
-    {% set tableRow = [
+    {% set _ = tableRows.push([
       {html: otherPrisonerPhoto, classes: "app-list__cell--photo"},
       {html: otherPrisonerProfileLink, classes: "app-list__cell--prisoner"},
       {html: reason, classes: "app-list__cell--reason"},
       {html: role, classes: "app-list__cell--role"},
       {html: restrictionType, classes: "app-list__cell--restriction-type"},
-      {html: comment, classes: "app-list__cell--comment" if listing == "open" else "app-list__cell--comment--wide"},
-      {html: lastUpdated, classes: "app-list__cell--date-updated"}
-    ] %}
-    {% if listing === "open" %}
-      {% set _ = tableRow.push(
-        {html: actions, classes: "app-list__cell--actions"}
-      ) %}
-    {% endif %}
-
-    {% set _ = tableRows.push(tableRow) %}
+      {html: comment, classes: "app-list__cell--comment"},
+      {html: lastUpdated, classes: "app-list__cell--date-updated"},
+      {html: actions, classes: "app-list__cell--actions"}
+    ]) %}
   {% endfor %}
 
   {% set caption -%}

--- a/server/views/pages/view.njk
+++ b/server/views/pages/view.njk
@@ -2,7 +2,7 @@
 
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
+{% from "moj/components/badge/macro.njk" import mojBadge %}
 
 {% from "../partials/keyPrisonerDetails.njk" import keyPrisonerDetails %}
 
@@ -109,10 +109,10 @@
 
       {% if nonAssociation.isClosed %}
         <p>
-          {{govukTag({
+          {{ mojBadge({
             text: "Closed",
-            classes: "govuk-tag--red"
-          })}}
+            classes: "moj-badge--red"
+          }) }}
         </p>
       {% endif %}
 

--- a/server/views/pages/view.njk
+++ b/server/views/pages/view.njk
@@ -4,6 +4,8 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 
+{% from "../partials/keyPrisonerDetails.njk" import keyPrisonerDetails %}
+
 {% set pageTitle = "Non-association details" %}
 
 {% block content %}
@@ -13,32 +15,14 @@
     {{ prisonerName }} and {{ otherPrisonerName }}
   </h1>
 
-  <div class="app-view__key-prisoner-details">
-    <img src="{{ routeUrls.prisonerPhoto(prisonerNumber) }}" alt="Photo of {{ prisonerName }}" class="app-prisoner-photo--small" />
-
-    <dl>
-      <dt class="govuk-visually-hidden">Prisoner</dt>
-      <a href="{{ dpsUrl }}/prisoner/{{ prisonerNumber }}">
-        {{ prisoner| reversedNameOfPerson }}
-      </a>
-      <br />
-      {{ prisonerNumber }}
-    </dl>
-
-    <dl>
-      <dt>Location</dt>
-      <dd>
-        {{ prisoner.cellLocation }}
-      </dd>
-    </dl>
-
+  {% call keyPrisonerDetails(routeUrls, prisoner) %}
     <dl>
       <dt>Role</dt>
       <dd>
         {{ nonAssociation.firstPrisonerRoleDescription if keyPrisonerIsFirst else nonAssociation.secondPrisonerRoleDescription }}
       </dd>
     </dl>
-  </div>
+  {% endcall %}
 
   <div class="govuk-grid-row govuk-!-margin-top-8">
     <div class="govuk-grid-column-two-thirds app-view__other-prisoner-details">

--- a/server/views/partials/keyPrisonerDetails.njk
+++ b/server/views/partials/keyPrisonerDetails.njk
@@ -1,0 +1,25 @@
+{% macro keyPrisonerDetails(routeUrls, prisoner) %}
+
+  <div class="app-key-prisoner-details">
+    <img src="{{ routeUrls.prisonerPhoto(prisoner.prisonerNumber) }}" alt="Photo of {{ prisoner| nameOfPerson }}" class="app-prisoner-photo--small" />
+
+    <dl>
+      <dt class="govuk-visually-hidden">Prisoner</dt>
+      <a href="{{ dpsUrl }}/prisoner/{{ prisoner.prisonerNumber }}">
+        {{ prisoner | reversedNameOfPerson }}
+      </a>
+      <br />
+      {{ prisoner.prisonerNumber }}
+    </dl>
+
+    <dl>
+      <dt>Location</dt>
+      <dd>
+        {{ prisoner.cellLocation }}
+      </dd>
+    </dl>
+
+    {{ caller() }}
+  </div>
+
+{% endmacro %}


### PR DESCRIPTION
Integrates the new "view" page into the user journeys, but the "list" page still only shows one table of non-associations. I.e. the list is still not split by establishment.