### PR TITLE
NON-193: List non-associations page

### DIFF
--- a/integration_tests/e2e/list.cy.ts
+++ b/integration_tests/e2e/list.cy.ts
@@ -30,6 +30,8 @@ context('List non-associations page', () => {
 
   it('should have open tab selected', () => {
     listPage.openTab.should('have.class', 'govuk-tabs__list-item--selected')
+    listPage.openTab.should('contain.text', '2 records')
+    listPage.closedTab.should('contain.text', '0 records')
   })
 
   it('should show a table of open non-associations', () => {

--- a/integration_tests/mockApis/offenderSearchApi.ts
+++ b/integration_tests/mockApis/offenderSearchApi.ts
@@ -2,7 +2,7 @@ import type { SuperAgentRequest } from 'superagent'
 
 import { stubFor } from './wiremock'
 import { OffenderSearchClient, type OffenderSearchResult } from '../../server/data/offenderSearch'
-import { davidJones, fredMills, oscarJones, andrewBrown } from '../../server/data/testData/offenderSearch'
+import { mockPrisoners } from '../../server/data/testData/offenderSearch'
 
 export default {
   stubOffenderSearchPing(): SuperAgentRequest {
@@ -20,11 +20,11 @@ export default {
   },
 
   /**
-   * Stub gettings details for all 4 mock prisoners
+   * Stub gettings details for all mock prisoners
    */
   stubOffenderSearchGetPrisoner(): Promise<unknown> {
     return Promise.all(
-      [davidJones, fredMills, oscarJones, andrewBrown].map(prisoner => {
+      mockPrisoners.map(prisoner => {
         return stubFor({
           request: {
             method: 'GET',

--- a/server/data/offenderSearch.ts
+++ b/server/data/offenderSearch.ts
@@ -28,6 +28,14 @@ export interface OffenderSearchResultOut extends BaseOffenderSearchResult {
 
 export type OffenderSearchResult = OffenderSearchResultIn | OffenderSearchResultTransfer | OffenderSearchResultOut
 
+export function isBeingTransferred(prisoner: OffenderSearchResult): prisoner is OffenderSearchResultTransfer {
+  return prisoner.prisonId === 'TRN'
+}
+
+export function isOutside(prisoner: OffenderSearchResult): prisoner is OffenderSearchResultOut {
+  return prisoner.prisonId === 'OUT'
+}
+
 export type OffenderSearchResults = {
   content: OffenderSearchResult[]
   totalElements: number

--- a/server/data/offenderSearch.ts
+++ b/server/data/offenderSearch.ts
@@ -1,15 +1,32 @@
 import config from '../config'
 import RestClient from './restClient'
 
-export type OffenderSearchResult = {
-  prisonId: string
-  prisonName: string
+interface BaseOffenderSearchResult {
   bookingId: number
   prisonerNumber: string
   firstName: string
   lastName: string
+}
+
+export interface OffenderSearchResultIn extends BaseOffenderSearchResult {
+  prisonId: string
+  prisonName: string
   cellLocation: string
 }
+
+export interface OffenderSearchResultTransfer extends BaseOffenderSearchResult {
+  prisonId: 'TRN'
+  prisonName: string
+  locationDescription: string
+}
+
+export interface OffenderSearchResultOut extends BaseOffenderSearchResult {
+  prisonId: 'OUT'
+  prisonName: string
+  locationDescription: string
+}
+
+export type OffenderSearchResult = OffenderSearchResultIn | OffenderSearchResultTransfer | OffenderSearchResultOut
 
 export type OffenderSearchResults = {
   content: OffenderSearchResult[]

--- a/server/data/offenderSearch.ts
+++ b/server/data/offenderSearch.ts
@@ -36,6 +36,10 @@ export function isOutside(prisoner: OffenderSearchResult): prisoner is OffenderS
   return prisoner.prisonId === 'OUT'
 }
 
+export function isInPrison(prisoner: OffenderSearchResult): prisoner is OffenderSearchResultIn {
+  return !isBeingTransferred(prisoner) && !isOutside(prisoner)
+}
+
 export type OffenderSearchResults = {
   content: OffenderSearchResult[]
   totalElements: number

--- a/server/data/testData/offenderSearch.ts
+++ b/server/data/testData/offenderSearch.ts
@@ -1,7 +1,13 @@
-import type { OffenderSearchClient, OffenderSearchResult, OffenderSearchResults } from '../offenderSearch'
+import type {
+  OffenderSearchClient,
+  OffenderSearchResultIn,
+  OffenderSearchResultOut,
+  OffenderSearchResultTransfer,
+  OffenderSearchResults,
+} from '../offenderSearch'
 import { SanitisedError } from '../../sanitisedError'
 
-export const davidJones: OffenderSearchResult = {
+export const davidJones: OffenderSearchResultIn = {
   prisonId: 'MDI',
   prisonName: 'Moorland (HMP)',
   bookingId: 12345,
@@ -11,7 +17,7 @@ export const davidJones: OffenderSearchResult = {
   cellLocation: '1-1-001',
 }
 
-export const fredMills: OffenderSearchResult = {
+export const fredMills: OffenderSearchResultIn = {
   prisonId: 'MDI',
   prisonName: 'Moorland (HMP)',
   bookingId: 12346,
@@ -21,7 +27,7 @@ export const fredMills: OffenderSearchResult = {
   cellLocation: '1-1-002',
 }
 
-export const oscarJones: OffenderSearchResult = {
+export const oscarJones: OffenderSearchResultIn = {
   prisonId: 'MDI',
   prisonName: 'Moorland (HMP)',
   bookingId: 12347,
@@ -31,7 +37,7 @@ export const oscarJones: OffenderSearchResult = {
   cellLocation: '1-1-003',
 }
 
-export const andrewBrown: OffenderSearchResult = {
+export const andrewBrown: OffenderSearchResultIn = {
   prisonId: 'MDI',
   prisonName: 'Moorland (HMP)',
   bookingId: 56789,
@@ -41,25 +47,41 @@ export const andrewBrown: OffenderSearchResult = {
   cellLocation: '1-1-004',
 }
 
+export const maxClarke: OffenderSearchResultTransfer = {
+  prisonId: 'TRN',
+  prisonName: 'Transfer',
+  bookingId: 12349,
+  prisonerNumber: 'C1234CC',
+  firstName: 'MAX',
+  lastName: 'CLARKE',
+  locationDescription: 'Transfer',
+}
+
+export const joePeters: OffenderSearchResultOut = {
+  prisonId: 'OUT',
+  prisonName: 'Outside',
+  bookingId: 12348,
+  prisonerNumber: 'B1234BB',
+  firstName: 'JOE',
+  lastName: 'PETERS',
+  locationDescription: 'Outside - released from Moorland (HMP)',
+}
+
+export const mockPrisoners = [davidJones, fredMills, oscarJones, andrewBrown, maxClarke, joePeters]
+
 export const mockGetPrisoner: OffenderSearchClient['getPrisoner'] = prisonerNumber => {
+  const result = mockPrisoners.find(prisoner => prisoner.prisonerNumber === prisonerNumber)
+  if (result) {
+    return Promise.resolve(result)
+  }
+
   const error: SanitisedError = {
     name: 'Error',
     status: 404,
     message: 'Not Found',
     stack: 'Not Found',
   }
-  switch (prisonerNumber) {
-    case davidJones.prisonerNumber:
-      return Promise.resolve(davidJones)
-    case fredMills.prisonerNumber:
-      return Promise.resolve(fredMills)
-    case oscarJones.prisonerNumber:
-      return Promise.resolve(oscarJones)
-    case andrewBrown.prisonerNumber:
-      return Promise.resolve(andrewBrown)
-    default:
-      return Promise.reject(error)
-  }
+  return Promise.reject(error)
 }
 
 export const sampleOffenderSearchResults: OffenderSearchResults = {

--- a/server/routes/add.test.ts
+++ b/server/routes/add.test.ts
@@ -63,7 +63,7 @@ describe('Add non-association details page', () => {
       .expect(404)
       .expect(res => {
         expect(res.text).not.toContain('Jones, David')
-        expect(offenderSearchClient.getPrisoner).toHaveBeenCalledTimes(1)
+        expect(offenderSearchClient.getPrisoner).toHaveBeenCalledTimes(2)
       })
   })
 

--- a/server/routes/add.test.ts
+++ b/server/routes/add.test.ts
@@ -5,7 +5,7 @@ import { SanitisedError } from '../sanitisedError'
 import { appWithAllRoutes } from './testutils/appSetup'
 import routeUrls from '../services/routeUrls'
 import { NonAssociationsApi } from '../data/nonAssociationsApi'
-import { OffenderSearchClient } from '../data/offenderSearch'
+import { OffenderSearchClient, type OffenderSearchResultOut } from '../data/offenderSearch'
 import { mockNonAssociation } from '../data/testData/nonAssociationsApi'
 import { davidJones, fredMills } from '../data/testData/offenderSearch'
 
@@ -17,7 +17,13 @@ jest.mock('../data/nonAssociationsApi', () => {
   const mockedModule = jest.createMockFromModule<Module>('../data/nonAssociationsApi')
   return { __esModule: true, ...realModule, NonAssociationsApi: mockedModule.NonAssociationsApi }
 })
-jest.mock('../data/offenderSearch')
+jest.mock('../data/offenderSearch', () => {
+  // ensures that sort and order constants are preserved
+  type Module = typeof import('../data/offenderSearch')
+  const realModule = jest.requireActual<Module>('../data/offenderSearch')
+  const mockedModule = jest.createMockFromModule<Module>('../data/offenderSearch')
+  return { __esModule: true, ...realModule, OffenderSearchClient: mockedModule.OffenderSearchClient }
+})
 
 // mock "key" prisoner
 const { prisonerNumber } = davidJones
@@ -87,6 +93,48 @@ describe('Add non-association details page', () => {
       .expect('Content-Type', /html/)
       .expect(() => {
         expect(offenderSearchClient.getPrisoner).not.toHaveBeenCalled()
+      })
+  })
+
+  it('should return 404 if prisoner is outside prison', () => {
+    const prisonerOutside = {
+      ...prisoner,
+      prisonId: 'OUT',
+      prisonName: 'Outside',
+      locationDescription: 'Outside - released from Moorland (HMP)',
+    } satisfies OffenderSearchResultOut
+    delete prisonerOutside.cellLocation
+
+    offenderSearchClient.getPrisoner.mockResolvedValueOnce(prisonerOutside)
+    offenderSearchClient.getPrisoner.mockResolvedValueOnce(otherPrisoner)
+
+    return request(app)
+      .get(routeUrls.add(prisonerNumber, otherPrisonerNumber))
+      .expect(404)
+      .expect(res => {
+        expect(res.text).not.toContain('Jones, David')
+        expect(offenderSearchClient.getPrisoner).toHaveBeenCalledTimes(2)
+      })
+  })
+
+  it('should return 404 if other prisoner is outside prison', () => {
+    const prisonerOutside = {
+      ...otherPrisoner,
+      prisonId: 'OUT',
+      prisonName: 'Outside',
+      locationDescription: 'Outside - released from Moorland (HMP)',
+    } satisfies OffenderSearchResultOut
+    delete prisonerOutside.cellLocation
+
+    offenderSearchClient.getPrisoner.mockResolvedValueOnce(prisoner)
+    offenderSearchClient.getPrisoner.mockResolvedValueOnce(prisonerOutside)
+
+    return request(app)
+      .get(routeUrls.add(prisonerNumber, otherPrisonerNumber))
+      .expect(404)
+      .expect(res => {
+        expect(res.text).not.toContain('Jones, David')
+        expect(offenderSearchClient.getPrisoner).toHaveBeenCalledTimes(2)
       })
   })
 

--- a/server/routes/add.ts
+++ b/server/routes/add.ts
@@ -13,7 +13,7 @@ import {
   restrictionTypeOptions,
   maxCommentLength,
 } from '../data/nonAssociationsApi'
-import { OffenderSearchClient, type OffenderSearchResult } from '../data/offenderSearch'
+import { isOutside, OffenderSearchClient, type OffenderSearchResult } from '../data/offenderSearch'
 import { createRedisClient } from '../data/redisClient'
 import TokenStore from '../data/tokenStore'
 import type { Services } from '../services'
@@ -44,6 +44,13 @@ export default function addRoutes(service: Services): Router {
         const otherPrisoner = await offenderSearchClient.getPrisoner(otherPrisonerNumber)
         const prisonerName = nameOfPerson(prisoner)
         const otherPrisonerName = nameOfPerson(otherPrisoner)
+
+        if (isOutside(prisoner)) {
+          throw new NotFound(`Cannot add a non-association to someone outside prison: ${prisonerNumber}`)
+        }
+        if (isOutside(otherPrisoner)) {
+          throw new NotFound(`Cannot add a non-association to someone outside prison: ${otherPrisonerNumber}`)
+        }
 
         Object.assign(res.locals, { prisoner, prisonerName, otherPrisoner, otherPrisonerName })
 

--- a/server/routes/add.ts
+++ b/server/routes/add.ts
@@ -40,8 +40,10 @@ export default function addRoutes(service: Services): Router {
 
         const systemToken = await hmppsAuthClient.getSystemClientToken(res.locals.user.username)
         const offenderSearchClient = new OffenderSearchClient(systemToken)
-        const prisoner = await offenderSearchClient.getPrisoner(prisonerNumber)
-        const otherPrisoner = await offenderSearchClient.getPrisoner(otherPrisonerNumber)
+        const [prisoner, otherPrisoner] = await Promise.all([
+          offenderSearchClient.getPrisoner(prisonerNumber),
+          offenderSearchClient.getPrisoner(otherPrisonerNumber),
+        ])
         const prisonerName = nameOfPerson(prisoner)
         const otherPrisonerName = nameOfPerson(otherPrisoner)
 

--- a/server/routes/list.test.ts
+++ b/server/routes/list.test.ts
@@ -294,8 +294,8 @@ describe('Non-associations list page', () => {
           expect(nonAssociationsApi.listNonAssociations).toHaveBeenCalledTimes(1)
           expect(prisonApi.getStaffDetails).toHaveBeenCalledTimes(2)
 
-          expect(res.text).toContain('Open (2 people)')
-          expect(res.text).toContain('Closed (0 people)')
+          expect(res.text).toContain('Open (2 records)')
+          expect(res.text).toContain('Closed (0 records)')
         })
     })
 
@@ -311,8 +311,8 @@ describe('Non-associations list page', () => {
           expect(nonAssociationsApi.listNonAssociations).toHaveBeenCalledTimes(1)
           expect(prisonApi.getStaffDetails).toHaveBeenCalledTimes(3)
 
-          expect(res.text).toContain('Open (1 person)')
-          expect(res.text).toContain('Closed (2 people)')
+          expect(res.text).toContain('Open (1 record)')
+          expect(res.text).toContain('Closed (2 records)')
         })
     })
   })

--- a/server/routes/list.ts
+++ b/server/routes/list.ts
@@ -31,7 +31,7 @@ const tableColumns: SortableTableColumns<
   { column: 'role', escapedHtml: 'Role', classes: 'app-list__cell--role', unsortable: true },
   {
     column: 'restrictionType',
-    escapedHtml: 'Where to keep apart',
+    escapedHtml: 'Where&nbsp;to keep&nbsp;apart',
     classes: 'app-list__cell--restriction-type',
     unsortable: true,
   },

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -8,7 +8,7 @@ import config from '../config'
 import type { Services } from '../services'
 import { checkedItems, multipleCheckedItems } from './checkedItems'
 import format from './format'
-import { convertToTitleCase, initialiseName, nameOfPerson, reversedNameOfPerson } from './utils'
+import { convertToTitleCase, initialiseName, nameOfPerson, reversedNameOfPerson, prisonerLocation } from './utils'
 
 export default function nunjucksSetup(app: express.Express, services: Services): void {
   app.set('view engine', 'njk')
@@ -50,11 +50,12 @@ export default function nunjucksSetup(app: express.Express, services: Services):
     },
   )
 
-  // name formatting
+  // name and description formatting
   njkEnv.addFilter('convertToTitleCase', convertToTitleCase)
   njkEnv.addFilter('initialiseName', initialiseName)
   njkEnv.addFilter('nameOfPerson', nameOfPerson)
   njkEnv.addFilter('reversedNameOfPerson', reversedNameOfPerson)
+  njkEnv.addFilter('prisonerLocation', prisonerLocation)
   njkEnv.addFilter('possessiveName', format.possessiveName)
 
   // date & number formatting

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -9,6 +9,7 @@ import type { Services } from '../services'
 import { checkedItems, multipleCheckedItems } from './checkedItems'
 import format from './format'
 import { convertToTitleCase, initialiseName, nameOfPerson, reversedNameOfPerson, prisonerLocation } from './utils'
+import { isBeingTransferred, isOutside, isInPrison } from '../data/offenderSearch'
 
 export default function nunjucksSetup(app: express.Express, services: Services): void {
   app.set('view engine', 'njk')
@@ -50,13 +51,18 @@ export default function nunjucksSetup(app: express.Express, services: Services):
     },
   )
 
-  // name and description formatting
+  // name formatting
   njkEnv.addFilter('convertToTitleCase', convertToTitleCase)
   njkEnv.addFilter('initialiseName', initialiseName)
   njkEnv.addFilter('nameOfPerson', nameOfPerson)
   njkEnv.addFilter('reversedNameOfPerson', reversedNameOfPerson)
-  njkEnv.addFilter('prisonerLocation', prisonerLocation)
   njkEnv.addFilter('possessiveName', format.possessiveName)
+
+  // prisoner utils
+  njkEnv.addFilter('prisonerLocation', prisonerLocation)
+  njkEnv.addFilter('isBeingTransferred', isBeingTransferred)
+  njkEnv.addFilter('isOutside', isOutside)
+  njkEnv.addFilter('isInPrison', isInPrison)
 
   // date & number formatting
   njkEnv.addFilter('dateAndTime', format.dateAndTime)

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -1,4 +1,5 @@
-import { convertToTitleCase, initialiseName, nameOfPerson, reversedNameOfPerson } from './utils'
+import { convertToTitleCase, initialiseName, nameOfPerson, reversedNameOfPerson, prisonerLocation } from './utils'
+import { davidJones, fredMills, joePeters, maxClarke } from '../data/testData/offenderSearch'
 
 describe('convert to title case', () => {
   it.each([
@@ -56,5 +57,40 @@ describe('display of prisoner names', () => {
         person.expected,
       )
     })
+  })
+})
+
+describe('prisoners’ locations', () => {
+  it.each([davidJones, fredMills])(
+    'for people who are in prison with a known cell location (e.g. $cellLocation)',
+    prisoner => {
+      expect(prisonerLocation(prisoner)).toEqual(prisoner.cellLocation)
+    },
+  )
+
+  it('for people who are in prison without a known cell location', () => {
+    const prisoner = { ...davidJones }
+    delete prisoner.cellLocation
+    expect(prisonerLocation(prisoner)).toEqual('Not known')
+  })
+
+  it('for people being transferred', () => {
+    expect(prisonerLocation(maxClarke)).toEqual('Transfer')
+  })
+
+  it('for people being transferred without a location description', () => {
+    const prisoner = { ...maxClarke }
+    delete prisoner.locationDescription
+    expect(prisonerLocation(prisoner)).toEqual('Transfer')
+  })
+
+  it('for people outside prison', () => {
+    expect(prisonerLocation(joePeters)).toEqual('Outside - released from Moorland (HMP)')
+  })
+
+  it('for people outside prison without a location description', () => {
+    const prisoner = { ...joePeters }
+    delete prisoner.locationDescription
+    expect(prisonerLocation(prisoner)).toEqual('Outside')
   })
 })

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -1,4 +1,5 @@
 import { convertToTitleCase, initialiseName, nameOfPerson, reversedNameOfPerson, prisonerLocation } from './utils'
+import { isBeingTransferred, isOutside, isInPrison } from '../data/offenderSearch'
 import { davidJones, fredMills, joePeters, maxClarke } from '../data/testData/offenderSearch'
 
 describe('convert to title case', () => {
@@ -65,6 +66,10 @@ describe('prisoners’ locations', () => {
     'for people who are in prison with a known cell location (e.g. $cellLocation)',
     prisoner => {
       expect(prisonerLocation(prisoner)).toEqual(prisoner.cellLocation)
+
+      expect(isBeingTransferred(prisoner)).toBeFalsy()
+      expect(isOutside(prisoner)).toBeFalsy()
+      expect(isInPrison(prisoner)).toBeTruthy()
     },
   )
 
@@ -72,25 +77,45 @@ describe('prisoners’ locations', () => {
     const prisoner = { ...davidJones }
     delete prisoner.cellLocation
     expect(prisonerLocation(prisoner)).toEqual('Not known')
+
+    expect(isBeingTransferred(prisoner)).toBeFalsy()
+    expect(isOutside(prisoner)).toBeFalsy()
+    expect(isInPrison(prisoner)).toBeTruthy()
   })
 
   it('for people being transferred', () => {
     expect(prisonerLocation(maxClarke)).toEqual('Transfer')
+
+    expect(isBeingTransferred(maxClarke)).toBeTruthy()
+    expect(isOutside(maxClarke)).toBeFalsy()
+    expect(isInPrison(maxClarke)).toBeFalsy()
   })
 
   it('for people being transferred without a location description', () => {
     const prisoner = { ...maxClarke }
     delete prisoner.locationDescription
     expect(prisonerLocation(prisoner)).toEqual('Transfer')
+
+    expect(isBeingTransferred(prisoner)).toBeTruthy()
+    expect(isOutside(prisoner)).toBeFalsy()
+    expect(isInPrison(prisoner)).toBeFalsy()
   })
 
   it('for people outside prison', () => {
     expect(prisonerLocation(joePeters)).toEqual('Outside - released from Moorland (HMP)')
+
+    expect(isBeingTransferred(joePeters)).toBeFalsy()
+    expect(isOutside(joePeters)).toBeTruthy()
+    expect(isInPrison(joePeters)).toBeFalsy()
   })
 
   it('for people outside prison without a location description', () => {
     const prisoner = { ...joePeters }
     delete prisoner.locationDescription
     expect(prisonerLocation(prisoner)).toEqual('Outside')
+
+    expect(isBeingTransferred(prisoner)).toBeFalsy()
+    expect(isOutside(prisoner)).toBeTruthy()
+    expect(isInPrison(prisoner)).toBeFalsy()
   })
 })

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -1,3 +1,5 @@
+import { isBeingTransferred, isOutside, type OffenderSearchResult } from '../data/offenderSearch'
+
 const properCase = (word: string): string =>
   word.length >= 1 ? word[0].toUpperCase() + word.toLowerCase().slice(1) : word
 
@@ -41,4 +43,17 @@ export const reversedNameOfPerson = (prisoner: { firstName: string; lastName: st
     return convertToTitleCase(prisoner.lastName)
   }
   return `${convertToTitleCase(prisoner.lastName)}, ${convertToTitleCase(prisoner.firstName)}`
+}
+
+/**
+ * Display location of a prisoner in prison, during transfer and outside/released
+ */
+export const prisonerLocation = (prisoner: OffenderSearchResult): string => {
+  if (isBeingTransferred(prisoner)) {
+    return prisoner.locationDescription ?? 'Transfer'
+  }
+  if (isOutside(prisoner)) {
+    return prisoner.locationDescription ?? 'Outside'
+  }
+  return prisoner.cellLocation ?? 'Not known'
 }

--- a/server/views/pages/list.njk
+++ b/server/views/pages/list.njk
@@ -60,11 +60,9 @@
       <a href="{{ dpsUrl }}/prisoner/{{ nonAssociation.otherPrisonerDetails.prisonerNumber }}">
         <span class="govuk-visually-hidden"> View prisoner profile for </span>
         {{ nonAssociation.otherPrisonerDetails | reversedNameOfPerson }}
-        <br />
-        {{ nonAssociation.otherPrisonerDetails.prisonerNumber }}
       </a>
       <br />
-      {{ nonAssociation.otherPrisonerDetails.cellLocation }}
+      {{ nonAssociation.otherPrisonerDetails.prisonerNumber }}
     {% endset %}
 
     {% set reason %}

--- a/server/views/pages/list.njk
+++ b/server/views/pages/list.njk
@@ -5,11 +5,11 @@
 
 {% from "../partials/keyPrisonerDetails.njk" import keyPrisonerDetails %}
 
-{% macro peopleCount(number) %}
+{% macro displayCount(number) %}
   {%- if number == 1 -%}
-    1 person
+    1 record
   {%- else -%}
-    {{ number }} people
+    {{ number }} records
   {%- endif -%}
 {% endmacro %}
 
@@ -39,12 +39,12 @@
     <ul class="govuk-tabs__list">
       <li class="govuk-tabs__list-item {% if listing === "open" %}govuk-tabs__list-item--selected{% endif %}">
         <a class="govuk-tabs__tab" href="{{ routeUrls.list(prisonerNumber) }}">
-          Open ({{ peopleCount(nonAssociationsList.openCount) }})
+          Open ({{ displayCount(nonAssociationsList.openCount) }})
         </a>
       </li>
       <li class="govuk-tabs__list-item {% if listing === "closed" %}govuk-tabs__list-item--selected{% endif %}">
         <a class="govuk-tabs__tab" href="{{ routeUrls.list(prisonerNumber, true) }}">
-          Closed ({{ peopleCount(nonAssociationsList.closedCount) }})
+          Closed ({{ displayCount(nonAssociationsList.closedCount) }})
         </a>
       </li>
     </ul>

--- a/server/views/pages/list.njk
+++ b/server/views/pages/list.njk
@@ -25,14 +25,16 @@
   </h1>
 
   {% call keyPrisonerDetails(routeUrls, prisoner) %}
-    <div class="app-key-prisoner-details--align-right">
-      {{ govukButton({
-        text: "Add new non-association",
-        classes: "app-button--blue",
-        element: "a",
-        href: routeUrls.prisonerSearch(prisonerNumber)
-      }) }}
-    </div>
+    {% if not prisoner | isOutside %}
+      <div class="app-key-prisoner-details--align-right">
+        {{ govukButton({
+          text: "Add new non-association",
+          classes: "app-button--blue",
+          element: "a",
+          href: routeUrls.prisonerSearch(prisonerNumber)
+        }) }}
+      </div>
+    {% endif %}
   {% endcall %}
 
   <nav class="govuk-!-margin-top-6">

--- a/server/views/pages/view.njk
+++ b/server/views/pages/view.njk
@@ -50,7 +50,7 @@
             ],
             [
               {text: "Location"},
-              {text: otherPrisoner.cellLocation}
+              {text: otherPrisoner | prisonerLocation}
             ]
           ]
         }) }}

--- a/server/views/partials/keyPrisonerDetails.njk
+++ b/server/views/partials/keyPrisonerDetails.njk
@@ -15,7 +15,7 @@
     <dl>
       <dt>Location</dt>
       <dd>
-        {{ prisoner.cellLocation }}
+        {{ prisoner | prisonerLocation }}
       </dd>
     </dl>
 


### PR DESCRIPTION
This is mostly about prisoners’ location display and the "list" page still only shows one table of non-associations. I.e. the list is still not split by establishment.