### PR TITLE
NON-193: Fix prisoner profile links

### DIFF
--- a/server/data/nonAssociationsApi.test.ts
+++ b/server/data/nonAssociationsApi.test.ts
@@ -277,9 +277,7 @@ describe('Non-associations API REST client', () => {
   describe('grouping locations of non-association lists', () => {
     function expectNoGroups(groups: NonAssociationGroups) {
       if (groups.type === 'noGroups') {
-        expect(
-          'samePrison' in groups || 'otherPrisons' in groups || 'anyPrison' in groups || 'transferOrOutside' in groups,
-        ).toBeFalsy()
+        expect('same' in groups || 'other' in groups || 'any' in groups || 'outside' in groups).toBeFalsy()
         return
       }
 
@@ -288,10 +286,10 @@ describe('Non-associations API REST client', () => {
 
     function expectThreeGroups(groups: NonAssociationGroups) {
       if (groups.type === 'threeGroups') {
-        expect('samePrison' in groups && 'otherPrisons' in groups && 'transferOrOutside' in groups).toBeTruthy()
+        expect('same' in groups && 'other' in groups && 'outside' in groups).toBeTruthy()
 
         expect(
-          groups.transferOrOutside.some(
+          groups.outside.some(
             item =>
               item.otherPrisonerDetails.prisonId !== transferPrisonId &&
               item.otherPrisonerDetails.prisonId !== outsidePrisonId,
@@ -300,20 +298,20 @@ describe('Non-associations API REST client', () => {
 
         return {
           toHaveLengths({
-            samePrisonCount,
-            otherPrisonCount,
-            transferOrOutsideCount,
+            sameCount,
+            otherCount,
+            outsideCount,
           }: {
-            samePrisonCount: number
-            otherPrisonCount: number
-            transferOrOutsideCount: number
+            sameCount: number
+            otherCount: number
+            outsideCount: number
           }) {
-            expect(groups.samePrison).toHaveLength(samePrisonCount)
-            expect(groups.otherPrisons).toHaveLength(otherPrisonCount)
-            expect(groups.transferOrOutside).toHaveLength(transferOrOutsideCount)
+            expect(groups.same).toHaveLength(sameCount)
+            expect(groups.other).toHaveLength(otherCount)
+            expect(groups.outside).toHaveLength(outsideCount)
 
-            const samePrisonSet = new Set(groups.samePrison.map(item => item.otherPrisonerDetails.prisonId))
-            if (samePrisonCount === 0) {
+            const samePrisonSet = new Set(groups.same.map(item => item.otherPrisonerDetails.prisonId))
+            if (sameCount === 0) {
               expect(samePrisonSet.size).toEqual(0)
             } else {
               expect(samePrisonSet.size).toEqual(1)
@@ -328,25 +326,25 @@ describe('Non-associations API REST client', () => {
     it('when the key prisoner is in a prison', () => {
       expectNoGroups(groupListByLocation(davidJones0NonAssociations))
       expectThreeGroups(groupListByLocation(davidJones1OpenNonAssociation)).toHaveLengths({
-        samePrisonCount: 1,
-        otherPrisonCount: 0,
-        transferOrOutsideCount: 0,
+        sameCount: 1,
+        otherCount: 0,
+        outsideCount: 0,
       })
       expectThreeGroups(groupListByLocation(davidJones1ClosedNonAssociation)).toHaveLengths({
-        samePrisonCount: 1,
-        otherPrisonCount: 0,
-        transferOrOutsideCount: 0,
+        sameCount: 1,
+        otherCount: 0,
+        outsideCount: 0,
       })
 
       expectThreeGroups(groupListByLocation(davidJones2OpenNonAssociations)).toHaveLengths({
-        samePrisonCount: 2,
-        otherPrisonCount: 0,
-        transferOrOutsideCount: 0,
+        sameCount: 2,
+        otherCount: 0,
+        outsideCount: 0,
       })
       expectThreeGroups(groupListByLocation(davidJones2ClosedNonAssociations)).toHaveLengths({
-        samePrisonCount: 2,
-        otherPrisonCount: 0,
-        transferOrOutsideCount: 0,
+        sameCount: 2,
+        otherCount: 0,
+        outsideCount: 0,
       })
 
       expectNoGroups(groupListByLocation(mockNonAssociationsList(davidJones, [])))
@@ -358,9 +356,9 @@ describe('Non-associations API REST client', () => {
         { prisoner: joePeters },
       ])
       expectThreeGroups(groupListByLocation(nonAssociations)).toHaveLengths({
-        samePrisonCount: 1,
-        otherPrisonCount: 1,
-        transferOrOutsideCount: 2,
+        sameCount: 1,
+        otherCount: 1,
+        outsideCount: 2,
       })
 
       nonAssociations = mockNonAssociationsList(davidJones, [
@@ -370,25 +368,25 @@ describe('Non-associations API REST client', () => {
         { prisoner: joePeters, closed: true },
       ])
       expectThreeGroups(groupListByLocation(nonAssociations)).toHaveLengths({
-        samePrisonCount: 1,
-        otherPrisonCount: 1,
-        transferOrOutsideCount: 2,
+        sameCount: 1,
+        otherCount: 1,
+        outsideCount: 2,
       })
 
       nonAssociations = mockNonAssociationsList(fredMills, [{ prisoner: walterSmith }, { prisoner: andrewBrown }])
       expectThreeGroups(groupListByLocation(nonAssociations)).toHaveLengths({
-        samePrisonCount: 0,
-        otherPrisonCount: 2,
-        transferOrOutsideCount: 0,
+        sameCount: 0,
+        otherCount: 2,
+        outsideCount: 0,
       })
     })
 
     function expectTwoGroups(groups: NonAssociationGroups) {
       if (groups.type === 'twoGroups') {
-        expect('anyPrison' in groups && 'transferOrOutside' in groups).toBeTruthy()
+        expect('any' in groups && 'outside' in groups).toBeTruthy()
 
         expect(
-          groups.transferOrOutside.some(
+          groups.outside.some(
             item =>
               item.otherPrisonerDetails.prisonId !== transferPrisonId &&
               item.otherPrisonerDetails.prisonId !== outsidePrisonId,
@@ -396,15 +394,9 @@ describe('Non-associations API REST client', () => {
         ).toBeFalsy()
 
         return {
-          toHaveLengths({
-            anyPrisonCount,
-            transferOrOutsideCount,
-          }: {
-            anyPrisonCount: number
-            transferOrOutsideCount: number
-          }) {
-            expect(groups.anyPrison).toHaveLength(anyPrisonCount)
-            expect(groups.transferOrOutside).toHaveLength(transferOrOutsideCount)
+          toHaveLengths({ anyPrisonCount, outsideCount }: { anyPrisonCount: number; outsideCount: number }) {
+            expect(groups.any).toHaveLength(anyPrisonCount)
+            expect(groups.outside).toHaveLength(outsideCount)
           },
         }
       }
@@ -419,7 +411,7 @@ describe('Non-associations API REST client', () => {
       nonAssociations = mockNonAssociationsList(maxClarke, [{ prisoner: davidJones }])
       expectTwoGroups(groupListByLocation(nonAssociations)).toHaveLengths({
         anyPrisonCount: 1,
-        transferOrOutsideCount: 0,
+        outsideCount: 0,
       })
 
       nonAssociations = mockNonAssociationsList(maxClarke, [
@@ -428,13 +420,13 @@ describe('Non-associations API REST client', () => {
       ])
       expectTwoGroups(groupListByLocation(nonAssociations)).toHaveLengths({
         anyPrisonCount: 1,
-        transferOrOutsideCount: 1,
+        outsideCount: 1,
       })
 
       nonAssociations = mockNonAssociationsList(maxClarke, [{ prisoner: joePeters }])
       expectTwoGroups(groupListByLocation(nonAssociations)).toHaveLengths({
         anyPrisonCount: 0,
-        transferOrOutsideCount: 1,
+        outsideCount: 1,
       })
     })
 
@@ -448,13 +440,13 @@ describe('Non-associations API REST client', () => {
       ])
       expectTwoGroups(groupListByLocation(nonAssociations)).toHaveLengths({
         anyPrisonCount: 2,
-        transferOrOutsideCount: 0,
+        outsideCount: 0,
       })
 
       nonAssociations = mockNonAssociationsList(joePeters, [{ prisoner: maxClarke, closed: true }])
       expectTwoGroups(groupListByLocation(nonAssociations)).toHaveLengths({
         anyPrisonCount: 0,
-        transferOrOutsideCount: 1,
+        outsideCount: 1,
       })
     })
   })

--- a/server/data/nonAssociationsApi.ts
+++ b/server/data/nonAssociationsApi.ts
@@ -474,15 +474,15 @@ interface NonAssociationNoGroups {
 
 interface NonAssociationGroupsWithPrison<Item extends BaseNonAssociationsListItem> {
   type: 'threeGroups'
-  samePrison: Item[]
-  otherPrisons: Item[]
-  transferOrOutside: Item[]
+  same: Item[]
+  other: Item[]
+  outside: Item[]
 }
 
 interface NonAssociationGroupsWithoutPrison<Item extends BaseNonAssociationsListItem> {
   type: 'twoGroups'
-  anyPrison: Item[]
-  transferOrOutside: Item[]
+  any: Item[]
+  outside: Item[]
 }
 
 export type NonAssociationGroups<
@@ -513,17 +513,17 @@ export function groupListByLocation<Item extends BaseNonAssociationsListItem>(
     // key prisoner is not in a prison
     const groups: NonAssociationGroupsWithoutPrison<Item> = {
       type: 'twoGroups',
-      anyPrison: [],
-      transferOrOutside: [],
+      any: [],
+      outside: [],
     }
     list.nonAssociations.forEach(item => {
       if (
         item.otherPrisonerDetails.prisonId === transferPrisonId ||
         item.otherPrisonerDetails.prisonId === outsidePrisonId
       ) {
-        groups.transferOrOutside.push(item)
+        groups.outside.push(item)
       } else {
-        groups.anyPrison.push(item)
+        groups.any.push(item)
       }
     })
     return groups
@@ -532,20 +532,20 @@ export function groupListByLocation<Item extends BaseNonAssociationsListItem>(
   // key prisoner is in some prison
   const groups: NonAssociationGroupsWithPrison<Item> = {
     type: 'threeGroups',
-    samePrison: [],
-    otherPrisons: [],
-    transferOrOutside: [],
+    same: [],
+    other: [],
+    outside: [],
   }
   list.nonAssociations.forEach(item => {
     if (
       item.otherPrisonerDetails.prisonId === transferPrisonId ||
       item.otherPrisonerDetails.prisonId === outsidePrisonId
     ) {
-      groups.transferOrOutside.push(item)
+      groups.outside.push(item)
     } else if (item.otherPrisonerDetails.prisonId === list.prisonId) {
-      groups.samePrison.push(item)
+      groups.same.push(item)
     } else {
-      groups.otherPrisons.push(item)
+      groups.other.push(item)
     }
   })
   return groups

--- a/server/data/nonAssociationsApi.ts
+++ b/server/data/nonAssociationsApi.ts
@@ -57,7 +57,7 @@ interface BaseNonAssociationsListItem {
     lastName: string
     prisonId: string
     prisonName: string
-    cellLocation: string
+    cellLocation?: string
   }
 }
 
@@ -83,7 +83,7 @@ export interface NonAssociationsList<
   lastName: string
   prisonId: string
   prisonName: string
-  cellLocation: string
+  cellLocation?: string
   openCount: number
   closedCount: number
   nonAssociations: Item[]

--- a/server/routes/list.ts
+++ b/server/routes/list.ts
@@ -150,8 +150,8 @@ export default function listRoutes(service: Services): Router {
         nonAssociationGroups = groupListByLocation(nonAssociationsList)
 
         if (nonAssociationGroups.type === 'threeGroups') {
-          nonAssociationGroups.samePrison = sortList(
-            nonAssociationGroups.samePrison,
+          nonAssociationGroups.same = sortList(
+            nonAssociationGroups.same,
             form.fields.sameSort.value,
             form.fields.sameOrder.value,
           )
@@ -163,8 +163,8 @@ export default function listRoutes(service: Services): Router {
             form.fields.sameOrder.value,
           )
 
-          nonAssociationGroups.otherPrisons = sortList(
-            nonAssociationGroups.otherPrisons,
+          nonAssociationGroups.other = sortList(
+            nonAssociationGroups.other,
             form.fields.otherSort.value,
             form.fields.otherOrder.value,
           )
@@ -176,8 +176,8 @@ export default function listRoutes(service: Services): Router {
             form.fields.otherOrder.value,
           )
 
-          nonAssociationGroups.transferOrOutside = sortList(
-            nonAssociationGroups.transferOrOutside,
+          nonAssociationGroups.outside = sortList(
+            nonAssociationGroups.outside,
             form.fields.outsideSort.value,
             form.fields.outsideOrder.value,
           )
@@ -189,8 +189,8 @@ export default function listRoutes(service: Services): Router {
             form.fields.outsideOrder.value,
           )
         } else if (nonAssociationGroups.type === 'twoGroups') {
-          nonAssociationGroups.anyPrison = sortList(
-            nonAssociationGroups.anyPrison,
+          nonAssociationGroups.any = sortList(
+            nonAssociationGroups.any,
             form.fields.anySort.value,
             form.fields.anyOrder.value,
           )
@@ -202,8 +202,8 @@ export default function listRoutes(service: Services): Router {
             form.fields.anyOrder.value,
           )
 
-          nonAssociationGroups.transferOrOutside = sortList(
-            nonAssociationGroups.transferOrOutside,
+          nonAssociationGroups.outside = sortList(
+            nonAssociationGroups.outside,
             form.fields.outsideSort.value,
             form.fields.outsideOrder.value,
           )

--- a/server/views/pages/list.njk
+++ b/server/views/pages/list.njk
@@ -3,7 +3,6 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 
 {% from "../partials/keyPrisonerDetails.njk" import keyPrisonerDetails %}
-{% from "../partials/nonAssociationGroup.njk" import nonAssociationGroup %}
 
 {% macro displayCount(number) %}
   {%- if number == 1 -%}
@@ -64,6 +63,9 @@
 
   {% elif nonAssociationGroups.type == "threeGroups" %}
 
+    {% set table = 'same' %}
+    {% set tableHead = tableHeads[table] %}
+    {% set nonAssociationsGroup = nonAssociationGroups[table] %}
     {% set emptyMessageHtml %}
       {% if listing == "closed" %}
         {{ prisonerName }} has no closed non-associations in {{ prisoner.prisonName }}.
@@ -71,16 +73,11 @@
         {{ prisonerName }} has no open non-associations in {{ prisoner.prisonName }}.
       {% endif %}
     {% endset %}
-    {{ nonAssociationGroup(
-      routeUrls,
-      'same',
-      tableHeads.same,
-      prisoner,
-      nonAssociationGroups.same,
-      listing,
-      emptyMessageHtml
-    ) }}
+    {% include "../partials/nonAssociationGroup.njk" %}
 
+    {% set table = 'other' %}
+    {% set tableHead = tableHeads[table] %}
+    {% set nonAssociationsGroup = nonAssociationGroups[table] %}
     {% set emptyMessageHtml %}
       {% if listing == "closed" %}
         {{ prisonerName }} has no closed non-associations in other establishments.
@@ -88,16 +85,11 @@
         {{ prisonerName }} has no open non-associations in other establishments.
       {% endif %}
     {% endset %}
-    {{ nonAssociationGroup(
-      routeUrls,
-      'other',
-      tableHeads.other,
-      prisoner,
-      nonAssociationGroups.other,
-      listing,
-      emptyMessageHtml
-    ) }}
+    {% include "../partials/nonAssociationGroup.njk" %}
 
+    {% set table = 'outside' %}
+    {% set tableHead = tableHeads[table] %}
+    {% set nonAssociationsGroup = nonAssociationGroups[table] %}
     {% set emptyMessageHtml %}
       {% if listing == "closed" %}
         {{ prisonerName }} has no closed non-associations outside an establishment.
@@ -105,18 +97,13 @@
         {{ prisonerName }} has no open non-associations outside an establishment.
       {% endif %}
     {% endset %}
-    {{ nonAssociationGroup(
-      routeUrls,
-      'outside',
-      tableHeads.outside,
-      prisoner,
-      nonAssociationGroups.outside,
-      listing,
-      emptyMessageHtml
-    ) }}
+    {% include "../partials/nonAssociationGroup.njk" %}
 
   {% elif nonAssociationGroups.type == "twoGroups" %}
 
+    {% set table = 'any' %}
+    {% set tableHead = tableHeads[table] %}
+    {% set nonAssociationsGroup = nonAssociationGroups[table] %}
     {% set emptyMessageHtml %}
       {% if listing == "closed" %}
         {{ prisonerName }} has no closed non-associations in an establishment.
@@ -124,16 +111,11 @@
         {{ prisonerName }} has no open non-associations in an establishment.
       {% endif %}
     {% endset %}
-    {{ nonAssociationGroup(
-      routeUrls,
-      'any',
-      tableHeads.any,
-      prisoner,
-      nonAssociationGroups.any,
-      listing,
-      emptyMessageHtml
-    ) }}
+    {% include "../partials/nonAssociationGroup.njk" %}
 
+    {% set table = 'outside' %}
+    {% set tableHead = tableHeads[table] %}
+    {% set nonAssociationsGroup = nonAssociationGroups[table] %}
     {% set emptyMessageHtml %}
       {% if listing == "closed" %}
         {{ prisonerName }} has no closed non-associations outside an establishment.
@@ -141,15 +123,7 @@
         {{ prisonerName }} has no open non-associations outside an establishment.
       {% endif %}
     {% endset %}
-    {{ nonAssociationGroup(
-      routeUrls,
-      'outside',
-      tableHeads.outside,
-      prisoner,
-      nonAssociationGroups.outside,
-      listing,
-      emptyMessageHtml
-    ) }}
+    {% include "../partials/nonAssociationGroup.njk" %}
 
   {% endif %}
 

--- a/server/views/pages/list.njk
+++ b/server/views/pages/list.njk
@@ -76,7 +76,7 @@
       'same',
       tableHeads.same,
       prisoner,
-      nonAssociationGroups.samePrison,
+      nonAssociationGroups.same,
       listing,
       emptyMessageHtml
     ) }}
@@ -93,7 +93,7 @@
       'other',
       tableHeads.other,
       prisoner,
-      nonAssociationGroups.otherPrisons,
+      nonAssociationGroups.other,
       listing,
       emptyMessageHtml
     ) }}
@@ -110,7 +110,7 @@
       'outside',
       tableHeads.outside,
       prisoner,
-      nonAssociationGroups.transferOrOutside,
+      nonAssociationGroups.outside,
       listing,
       emptyMessageHtml
     ) }}
@@ -129,7 +129,7 @@
       'any',
       tableHeads.any,
       prisoner,
-      nonAssociationGroups.anyPrison,
+      nonAssociationGroups.any,
       listing,
       emptyMessageHtml
     ) }}
@@ -146,7 +146,7 @@
       'outside',
       tableHeads.outside,
       prisoner,
-      nonAssociationGroups.transferOrOutside,
+      nonAssociationGroups.outside,
       listing,
       emptyMessageHtml
     ) }}

--- a/server/views/partials/nonAssociationGroup.njk
+++ b/server/views/partials/nonAssociationGroup.njk
@@ -1,93 +1,89 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 
-{% macro nonAssociationGroup(routeUrls, table, tableHead, prisoner, nonAssociationsGroup, listing, emptyMessageHtml) %}
+<h2 class="govuk-heading-m govuk-!-margin-top-6">
+  {%- if table == 'same' -%}
+    {{ prisoner.prisonName }}
+  {%- elif table == 'other' -%}
+    Other establishments
+  {%- elif table == 'any' -%}
+    In establishments
+  {%- elif table == 'outside' -%}
+    Not currently in an establishment
+  {%- endif -%}
+</h2>
 
-  <h2 class="govuk-heading-m govuk-!-margin-top-6">
-    {%- if table == 'same' -%}
-      {{ prisoner.prisonName }}
-    {%- elif table == 'other' -%}
-      Other establishments
-    {%- elif table == 'any' -%}
-      In establishments
-    {%- elif table == 'outside' -%}
-      Not currently in an establishment
-    {%- endif -%}
-  </h2>
+{% set tableRows = [] %}
+{% for nonAssociation in nonAssociationsGroup %}
+  {% set otherPrisonerPhoto %}
+    <img src="{{ routeUrls.prisonerPhoto(nonAssociation.otherPrisonerDetails.prisonerNumber) }}" alt="Photo of {{ nonAssociation.otherPrisonerDetails | nameOfPerson }}" class="app-prisoner-photo" />
+  {% endset %}
 
-  {% set tableRows = [] %}
-  {% for nonAssociation in nonAssociationsGroup %}
-    {% set otherPrisonerPhoto %}
-      <img src="{{ routeUrls.prisonerPhoto(nonAssociation.otherPrisonerDetails.prisonerNumber) }}" alt="Photo of {{ nonAssociation.otherPrisonerDetails | nameOfPerson }}" class="app-prisoner-photo" />
-    {% endset %}
+  {% set otherPrisonerProfileLink %}
+    <a href="{{ dpsUrl }}/prisoner/{{ nonAssociation.otherPrisonerDetails.prisonerNumber }}">
+      <span class="govuk-visually-hidden">View prisoner profile for</span>
+      {{ nonAssociation.otherPrisonerDetails | reversedNameOfPerson }}
+    </a>
+    <br />
+    {{ nonAssociation.otherPrisonerDetails.prisonerNumber }}
+  {% endset %}
 
-    {% set otherPrisonerProfileLink %}
-      <a href="{{ dpsUrl }}/prisoner/{{ nonAssociation.otherPrisonerDetails.prisonerNumber }}">
-        <span class="govuk-visually-hidden">View prisoner profile for</span>
-        {{ nonAssociation.otherPrisonerDetails | reversedNameOfPerson }}
-      </a>
-      <br />
-      {{ nonAssociation.otherPrisonerDetails.prisonerNumber }}
-    {% endset %}
+  {% set location %}
+    {% if table == 'same' %}
+      {{ nonAssociation.otherPrisonerDetails.cellLocation }}
+    {% elif table == 'other' or table == 'any' %}
+      {{ nonAssociation.otherPrisonerDetails.prisonName }}
+    {% else %}
+      {{ nonAssociation.otherPrisonerDetails | prisonerLocation }}
+    {% endif %}
+  {% endset %}
 
-    {% set location %}
-      {% if table == 'same' %}
-        {{ nonAssociation.otherPrisonerDetails.cellLocation }}
-      {% elif table == 'other' or table == 'any' %}
-        {{ nonAssociation.otherPrisonerDetails.prisonName }}
-      {% else %}
-        {{ nonAssociation.otherPrisonerDetails | prisonerLocation }}
-      {% endif %}
-    {% endset %}
+  {% set role %}
+    {{ nonAssociation.roleDescription }}
+  {% endset %}
 
-    {% set role %}
-      {{ nonAssociation.roleDescription }}
-    {% endset %}
+  {% set restrictionType %}
+    {{ nonAssociation.restrictionTypeDescription }}
+  {% endset %}
 
-    {% set restrictionType %}
-      {{ nonAssociation.restrictionTypeDescription }}
-    {% endset %}
+  {% set lastUpdated %}
+    {{ nonAssociation.whenUpdated | shortDate }}
+  {% endset %}
 
-    {% set lastUpdated %}
-      {{ nonAssociation.whenUpdated | shortDate }}
-    {% endset %}
+  {% set actions %}
+    <a href="{{ routeUrls.view(prisoner.prisonerNumber, nonAssociation.id) }}">View details</a>
+  {% endset %}
 
-    {% set actions %}
-      <a href="{{ routeUrls.view(prisoner.prisonerNumber, nonAssociation.id) }}">View details</a>
-    {% endset %}
+  {% set _ = tableRows.push([
+    {html: otherPrisonerPhoto, classes: "app-list__cell--photo"},
+    {html: otherPrisonerProfileLink, classes: "app-list__cell--prisoner"},
+    {html: location, classes: "app-list__cell--location"},
+    {html: role, classes: "app-list__cell--role"},
+    {html: restrictionType, classes: "app-list__cell--restriction-type"},
+    {html: lastUpdated, classes: "app-list__cell--date-updated"},
+    {html: actions, classes: "app-list__cell--actions"}
+  ]) %}
+{% endfor %}
 
-    {% set _ = tableRows.push([
-      {html: otherPrisonerPhoto, classes: "app-list__cell--photo"},
-      {html: otherPrisonerProfileLink, classes: "app-list__cell--prisoner"},
-      {html: location, classes: "app-list__cell--location"},
-      {html: role, classes: "app-list__cell--role"},
-      {html: restrictionType, classes: "app-list__cell--restriction-type"},
-      {html: lastUpdated, classes: "app-list__cell--date-updated"},
-      {html: actions, classes: "app-list__cell--actions"}
-    ]) %}
-  {% endfor %}
+{% set caption -%}
+  Non-associations for {{ prisonerName }}
+{%- endset %}
 
-  {% set caption -%}
-    Non-associations for {{ prisonerName }}
-  {%- endset %}
+{% if tableRows.length > 0 %}
 
-  {% if tableRows.length > 0 %}
+  <div class="app-sortable-table-container govuk-!-margin-bottom-9">
+    {{ govukTable({
+      caption: caption,
+      captionClasses: "govuk-visually-hidden",
+      classes: "app-sortable-table",
+      head: tableHead,
+      rows: tableRows
+    }) }}
+  </div>
 
-    <div class="app-sortable-table-container govuk-!-margin-bottom-9">
-      {{ govukTable({
-        caption: caption,
-        captionClasses: "govuk-visually-hidden",
-        classes: "app-sortable-table",
-        head: tableHead,
-        rows: tableRows
-      }) }}
-    </div>
+{% else %}
 
-  {% else %}
+  <p>
+    {{ emptyMessageHtml | safe }}
+  </p>
 
-    <p>
-      {{ emptyMessageHtml | safe }}
-    </p>
-
-  {% endif %}
-
-{% endmacro %}
+{% endif %}


### PR DESCRIPTION
Nunjucks macros do not inherit variables visible in the template so it's easy to forget to pass them in. Here, `dpsUrl` was missing and now that so many parameters would need to be passed in it seems better to use a plain include.