### PR TITLE
Allow empty constructors because they can be used in typescript to set instance variables

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -142,7 +142,8 @@
         "printWidth": 120,
         "semi": false
       }
-    ]
+    ],
+    "no-empty-function": ["error", { "allow": ["constructors", "arrowFunctions"] }]
   },
 
   "reportUnusedDisableDirectives": true

--- a/server/data/hmppsAuthClient.ts
+++ b/server/data/hmppsAuthClient.ts
@@ -41,7 +41,6 @@ export interface UserRole {
 }
 
 export default class HmppsAuthClient {
-  // eslint-disable-next-line no-empty-function
   constructor(private readonly tokenStore: TokenStore) {}
 
   private static restClient(token: string): RestClient {

--- a/server/routes/list.test.ts
+++ b/server/routes/list.test.ts
@@ -235,7 +235,6 @@ describe('Non-associations list page', () => {
     class ExpectNonAssociationList {
       private table: Table
 
-      // eslint-disable-next-line no-empty-function
       constructor(private readonly closed = false) {}
 
       shouldHaveThreeGroups(table: 'same' | 'other' | 'outside'): request.Test {

--- a/server/services/dpsComponentService.ts
+++ b/server/services/dpsComponentService.ts
@@ -1,7 +1,6 @@
 import DpsFeComponentsClient, { AvailableComponent, Component } from '../data/dpsFeComponentsClient'
 
 export default class FeComponentsService {
-  // eslint-disable-next-line no-empty-function
   constructor(private readonly dpsFeComponentsClient: DpsFeComponentsClient) {}
 
   public async getComponent(component: AvailableComponent, token: string): Promise<Component> {

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -8,7 +8,6 @@ export interface UserDetails extends UserCaseloads {
 }
 
 export default class UserService {
-  // eslint-disable-next-line no-empty-function
   constructor(private readonly hmppsAuthClient: HmppsAuthClient) {}
 
   async getUser(token: string): Promise<UserDetails> {


### PR DESCRIPTION
(copied from other UI projects)