### PR TITLE
NON-228: Updated titles

### DIFF
--- a/integration_tests/e2e/add.cy.ts
+++ b/integration_tests/e2e/add.cy.ts
@@ -17,7 +17,7 @@ context('Add non-association page', () => {
 
   it('navigate to add non-association', () => {
     listPage.addButton.click()
-    cy.title().should('eq', 'Search for a prisoner')
+    cy.title().should('eq', 'Search for a prisoner – Digital Prison Services')
   })
 
   it('should allow adding a new non-association', () => {

--- a/integration_tests/e2e/list.cy.ts
+++ b/integration_tests/e2e/list.cy.ts
@@ -12,7 +12,7 @@ context('List non-associations page', () => {
   })
 
   it('has correct title', () => {
-    cy.title().should('eq', 'David Jones’ non-associations')
+    cy.title().should('eq', 'Non-associations – Digital Prison Services')
   })
 
   it('has correct breadcrumb', () => {

--- a/server/views/pages/addConfirmation.njk
+++ b/server/views/pages/addConfirmation.njk
@@ -2,7 +2,7 @@
 
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
 
-{% set pageTitle = "Non-association has been added" %}
+{% set pageTitle = "Non-association added" %}
 
 {% block content %}
   <div class="govuk-grid-row">

--- a/server/views/pages/closeConfirmation.njk
+++ b/server/views/pages/closeConfirmation.njk
@@ -2,7 +2,7 @@
 
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
 
-{% set pageTitle = "Non-association has been closed" %}
+{% set pageTitle = "Non-association closed" %}
 
 {% block content %}
   <div class="govuk-grid-row">

--- a/server/views/pages/list.njk
+++ b/server/views/pages/list.njk
@@ -10,7 +10,7 @@
   {%- endif -%}
 {% endmacro %}
 
-{% set pageTitle = prisonerName | possessiveName + " non-associations" %}
+{% set pageTitle = "Non-associations" %}
 
 {% block content %}
 

--- a/server/views/pages/updateConfirmation.njk
+++ b/server/views/pages/updateConfirmation.njk
@@ -2,7 +2,7 @@
 
 {% from "govuk/components/panel/macro.njk" import govukPanel %}
 
-{% set pageTitle = "Non-association has been updated" %}
+{% set pageTitle = "Non-association updated" %}
 
 {% block content %}
   <div class="govuk-grid-row">

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -30,7 +30,7 @@
 
 {% endblock %}
 
-{% block pageTitle %}{{ pageTitle | default(applicationName) }}{% endblock %}
+{% block pageTitle %}{{ pageTitle | default(applicationName) }} – Digital Prison Services{% endblock %}
 
 {% block header %}
   {% if feComponents.header %}

--- a/server/views/partials/nonAssociationForm.njk
+++ b/server/views/partials/nonAssociationForm.njk
@@ -6,7 +6,7 @@
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 
-{% set pageTitle = "Non-association details" %}
+{% set pageTitle = "Enter non-association details" %}
 
 {% block content %}
   <div class="govuk-grid-row">
@@ -15,7 +15,7 @@
       {% include "../partials/messages.njk" %}
       {% include "../partials/formErrorSummary.njk" %}
 
-      <h1 class="govuk-heading-l">{{ pageTitle }}</h1>
+      <h1 class="govuk-heading-l">Non-association details</h1>
 
       <form method="post" novalidate>
         {% call govukFieldset({


### PR DESCRIPTION
- all pages have the trailing `– Digital Prison Services`
- removed prisoner name from title of list of non-associations page
- simplified/tweak other titles

See spreadsheet with copy changes:

https://docs.google.com/spreadsheets/d/1SUI3USAqR3Drc3148SIk3mN5-zmBGKAkm5rl08whSnA/edit#gid=0