### PR TITLE
NON-209: Track clicks on confirmation pages

### DIFF
--- a/assets/js/application.js
+++ b/assets/js/application.js
@@ -6,7 +6,7 @@ window.MOJFrontend.initAll()
  * @param {string} eventName
  * @param {Record<string, string>} [eventParameters]
  */
-// eslint-disable-next-line no-unused-vars
+
 function sendGoogleAnalyticsEvent(eventName, eventParameters) {
   if (typeof gtag === 'function') {
     if (eventParameters) {
@@ -31,4 +31,22 @@ $(function pageLoaded() {
       })
     }
   })
+})
+
+function gaEventHandler() {
+  const elem = $(this)
+
+  const gaCategory = elem.data('ga-category') || null
+  const gaAction = elem.data('ga-action') || null
+  const gaLabel = elem.data('ga-label') || null
+
+  sendGoogleAnalyticsEvent('non_associations_event', {
+    category: gaCategory,
+    action: gaAction,
+    label: gaLabel,
+  })
+}
+
+$(() => {
+  $('a[data-ga-category]').on('click', gaEventHandler)
 })

--- a/integration_tests/e2e/add.cy.ts
+++ b/integration_tests/e2e/add.cy.ts
@@ -49,5 +49,17 @@ context('Add non-association page', () => {
     addDetailsPage.saveButton.click()
 
     Page.verifyOnPage(AddConfirmationPage)
+
+    // Clicking on the link sends a GA event
+    cy.trackGoogleAnalyticsCalls().then(googleAnalyticsTracker => {
+      cy.get('a[data-ga-category]').click()
+      cy.then(() => {
+        googleAnalyticsTracker.shouldHaveLastSent('event', 'non_associations_event', {
+          category: 'Add confirmation > Clicked on key prisoner link',
+          action: null,
+          label: null,
+        })
+      })
+    })
   })
 })

--- a/integration_tests/e2e/close.cy.ts
+++ b/integration_tests/e2e/close.cy.ts
@@ -30,5 +30,17 @@ context('Close prisoner non-association page', () => {
     closePage.getCloseButton().click()
 
     Page.verifyOnPage(CloseConfirmationPage)
+
+    // Clicking on the link sends a GA event
+    cy.trackGoogleAnalyticsCalls().then(googleAnalyticsTracker => {
+      cy.get('a[data-ga-category]').click()
+      cy.then(() => {
+        googleAnalyticsTracker.shouldHaveLastSent('event', 'non_associations_event', {
+          category: 'Close confirmation > Clicked on key prisoner link',
+          action: null,
+          label: null,
+        })
+      })
+    })
   })
 })

--- a/integration_tests/e2e/update.cy.ts
+++ b/integration_tests/e2e/update.cy.ts
@@ -30,5 +30,17 @@ context('Update prisoner non-association page', () => {
     updatePage.saveButton.click()
 
     Page.verifyOnPage(UpdateConfirmationPage)
+
+    // Clicking on the link sends a GA event
+    cy.trackGoogleAnalyticsCalls().then(googleAnalyticsTracker => {
+      cy.get('a[data-ga-category]').click()
+      cy.then(() => {
+        googleAnalyticsTracker.shouldHaveLastSent('event', 'non_associations_event', {
+          category: 'Update confirmation > Clicked on key prisoner link',
+          action: null,
+          label: null,
+        })
+      })
+    })
   })
 })

--- a/server/views/pages/addConfirmation.njk
+++ b/server/views/pages/addConfirmation.njk
@@ -14,7 +14,7 @@
       }) }}
 
       <p class="govuk-!-margin-top-6">
-        <a href="{{ routeUrls.list(prisonerNumber) }}">
+        <a href="{{ routeUrls.list(prisonerNumber) }}" data-ga-category="Add confirmation > Clicked on key prisoner link">
           View {{ prisonerName | possessiveName }} non-associations
         </a>
       </p>

--- a/server/views/pages/closeConfirmation.njk
+++ b/server/views/pages/closeConfirmation.njk
@@ -14,7 +14,7 @@
       }) }}
 
       <p class="govuk-!-margin-top-6">
-        <a href="{{ routeUrls.list(prisonerNumber, true) }}">
+        <a href="{{ routeUrls.list(prisonerNumber, true) }}" data-ga-category="Close confirmation > Clicked on key prisoner link">
           View {{ prisonerName | possessiveName }} non-associations
         </a>
       </p>

--- a/server/views/pages/updateConfirmation.njk
+++ b/server/views/pages/updateConfirmation.njk
@@ -14,7 +14,7 @@
       }) }}
 
       <p class="govuk-!-margin-top-6">
-        <a href="{{ routeUrls.list(prisonerNumber) }}">
+        <a href="{{ routeUrls.list(prisonerNumber) }}" data-ga-category="Update confirmation > Clicked on key prisoner link">
           View {{ prisonerName | possessiveName }} non-associations
         </a>
       </p>


### PR DESCRIPTION
The Add/Update/Close confirmation pages have a link that takes the user
back to the "key" prisoner's non-associations page.

Clicking on these now publishes a custom GA event (with name `non_associations_event`).

The `category` field in the event can be used to filter/discriminate between
pages in a GA report.

In this specific case `action`/`label` fields are blank but if we'll ever add more custom GA events
it may make sense for these future events to also potentially set `action` and/or `label` (
by setting the `data-ga-action` and/or `data-ga-label` attributes).
For the simple case of clicks these are not necessary.

NOTE: The `active_case_load` property is also sent alongside in the published events, even if this is not passed explicitly on send.