### PR TITLE
NON-281: Relax caseload restrictions for modifying non-associations

### DIFF
--- a/integration_tests/e2e/add.cy.ts
+++ b/integration_tests/e2e/add.cy.ts
@@ -127,7 +127,7 @@ context('Add non-association page', () => {
       expect(walterSmithRow[1]).to.contain('Smith, Walter')
       expect(walterSmithRow[3]).to.contain('2-4-002')
       expect(walterSmithRow[4]).to.contain('Brixton')
-      expect(walterSmithRow[5]).not.to.contain('Select prisoner')
+      expect(walterSmithRow[5]).to.contain('Select prisoner')
 
       expect(maxClarkeRow[1]).to.contain('Clarke, Max')
       expect(maxClarkeRow[3]).to.contain('Transfer')

--- a/server/data/constants.ts
+++ b/server/data/constants.ts
@@ -15,7 +15,7 @@ export const userRolePrison = 'ROLE_PRISON' as const
 export const userRoleGlobalSearch = 'ROLE_GLOBAL_SEARCH' as const
 
 /**
- * Users without inactive bookings cannot search for released prisoners not link out to profiles to those individuals
+ * Users without inactive bookings cannot search for released prisoners nor link out to profiles of those individuals
  */
 export const userRoleInactiveBookings = 'ROLE_INACTIVE_BOOKINGS' as const
 

--- a/server/middleware/userPermissions.test.ts
+++ b/server/middleware/userPermissions.test.ts
@@ -17,8 +17,16 @@ import {
   joePeters,
   mockMovePrisoner,
 } from '../data/testData/offenderSearch'
-import { mockUser, mockCaseloads } from '../routes/testutils/appSetup'
-import userPermissions from './userPermissions'
+import {
+  mockUser,
+  mockNonPrisonUser,
+  mockReadOnlyUser,
+  mockUserWithoutGlobalSearch,
+  mockUserWithGlobalSearch,
+  mockUserWithInactiveBookings,
+  mockCaseloads,
+} from '../routes/testutils/appSetup'
+import userPermissions, { type UserPermissions } from './userPermissions'
 
 function expectUser(user: Express.User) {
   const req = jest.fn() as unknown as jest.Mocked<Request>
@@ -37,6 +45,10 @@ function expectUser(user: Express.User) {
   const { permissions } = res.locals.user
 
   return {
+    get permissions(): UserPermissions {
+      return permissions
+    },
+
     toHavePermissionFlags(
       flags: Pick<Express.User['permissions'], 'read' | 'write' | 'globalSearch' | 'inactiveBookings'>,
     ): void {
@@ -76,10 +88,7 @@ type HasWritePermissionScenarios = ReadonlyArray<{
 
 describe('userPermissions', () => {
   it('should set no read/write flags if the user is missing roles', () => {
-    expectUser({
-      ...mockUser,
-      roles: [],
-    }).toHavePermissionFlags({
+    expectUser(mockNonPrisonUser).toHavePermissionFlags({
       read: false,
       write: false,
       globalSearch: false,
@@ -88,10 +97,7 @@ describe('userPermissions', () => {
   })
 
   it('should set read flag if user has necessary role', () => {
-    expectUser({
-      ...mockUser,
-      roles: [userRolePrison],
-    }).toHavePermissionFlags({
+    expectUser(mockReadOnlyUser).toHavePermissionFlags({
       read: true,
       write: false,
       globalSearch: false,
@@ -100,10 +106,7 @@ describe('userPermissions', () => {
   })
 
   it('should set read & write flags if user has necessary roles', () => {
-    expectUser({
-      ...mockUser,
-      roles: [userRolePrison, userRoleManageNonAssociations],
-    }).toHavePermissionFlags({
+    expectUser(mockUserWithoutGlobalSearch).toHavePermissionFlags({
       read: true,
       write: true,
       globalSearch: false,
@@ -137,10 +140,7 @@ describe('userPermissions', () => {
     })
 
     it('if they also have write permission', () => {
-      expectUser({
-        ...mockUser,
-        roles: [userRolePrison, userRoleGlobalSearch, userRoleManageNonAssociations],
-      }).toHavePermissionFlags({
+      expectUser(mockUserWithGlobalSearch).toHavePermissionFlags({
         read: true,
         write: true,
         globalSearch: true,
@@ -400,6 +400,136 @@ describe('userPermissions', () => {
       },
     ] satisfies HasWritePermissionScenarios)('$scenario', ({ user, prisoner, otherPrisoner }) => {
       expectUser(user).toNotHaveWritePermission(prisoner, otherPrisoner)
+    })
+  })
+
+  describe('should check roles and caseloads', () => {
+    const labels = ['in caseloads', 'not in caseloads', 'being transferred', 'not in an establishment']
+    const prisoners = [fredMills, andrewBrown, maxClarke, joePeters]
+
+    type Expected = 'Y' | 'N' | ' '
+    type ExpectationRow = readonly [Expected, Expected, Expected, Expected]
+    type ExpectationTable = readonly [ExpectationRow, ExpectationRow, ExpectationRow, ExpectationRow]
+    type Challenge = (
+      userPermissions: UserPermissions,
+      prisoner: OffenderSearchResult,
+      otherPrisoner: OffenderSearchResult,
+    ) => boolean
+
+    function expectAllCombinations(user: Express.User, challenge: Challenge, expected: ExpectationTable): void {
+      const { permissions } = expectUser(user)
+
+      prisoners.forEach((prisoner, rowIndex) => {
+        const prisonerLabel = labels[rowIndex]
+
+        prisoners.forEach((otherPrisoner, columnIndex) => {
+          const otherPrisonerLabel = labels[columnIndex]
+
+          let expectation = expected[rowIndex][columnIndex]
+          if (expectation === ' ') {
+            // non-associations are symmetrical: ' ' means use inverse combination’s expected result
+            expectation = expected[columnIndex][rowIndex]
+          }
+          const expectedResult = expectation === 'Y'
+
+          it(`challenge for a non-association between a prionser ${prisonerLabel} and a prisoner ${otherPrisonerLabel} should be ${expectedResult}`, () => {
+            const result = challenge(permissions, prisoner, otherPrisoner)
+            expect(result).toEqual(expectedResult)
+          })
+        })
+      })
+    }
+
+    describe('and forbid non-prison users from viewing or modifying any non-associations', () => {
+      expectAllCombinations(
+        mockNonPrisonUser,
+        (permissions, prisoner, otherPrisoner) => {
+          return permissions.read || permissions.canWriteNonAssociation(prisoner, otherPrisoner)
+        },
+        [
+          ['N', 'N', 'N', 'N'],
+          [' ', 'N', 'N', 'N'],
+          [' ', ' ', 'N', 'N'],
+          [' ', ' ', ' ', 'N'],
+        ],
+      )
+    })
+
+    describe('and allow prison users to view non-associations', () => {
+      for (const user of [
+        mockReadOnlyUser,
+        mockUserWithoutGlobalSearch,
+        mockUserWithGlobalSearch,
+        mockUserWithInactiveBookings,
+        mockUser,
+      ]) {
+        expectAllCombinations(user, permissions => permissions.read, [
+          ['Y', 'Y', 'Y', 'Y'],
+          [' ', 'Y', 'Y', 'Y'],
+          [' ', ' ', 'Y', 'Y'],
+          [' ', ' ', ' ', 'Y'],
+        ])
+      }
+    })
+
+    describe('and allow prison users to only modify non-associations in their caseloads', () => {
+      expectAllCombinations(
+        mockUserWithoutGlobalSearch,
+        (permissions, prisoner, otherPrisoner) => {
+          return permissions.read && permissions.canWriteNonAssociation(prisoner, otherPrisoner)
+        },
+        [
+          ['Y', 'N', 'N', 'N'],
+          [' ', 'N', 'N', 'N'],
+          [' ', ' ', 'N', 'N'],
+          [' ', ' ', ' ', 'N'],
+        ],
+      )
+    })
+
+    describe('and allow prison users with global search to modify non-associations in their caseloads or in transfer', () => {
+      expectAllCombinations(
+        mockUserWithGlobalSearch,
+        (permissions, prisoner, otherPrisoner) => {
+          return permissions.read && permissions.canWriteNonAssociation(prisoner, otherPrisoner)
+        },
+        [
+          ['Y', 'N', 'Y', 'N'],
+          [' ', 'N', 'N', 'N'],
+          [' ', ' ', 'Y', 'N'],
+          [' ', ' ', ' ', 'N'],
+        ],
+      )
+    })
+
+    describe('and allow prison users with inactive bookings to modify non-associations in their caseloads or outside', () => {
+      expectAllCombinations(
+        mockUserWithInactiveBookings,
+        (permissions, prisoner, otherPrisoner) => {
+          return permissions.read && permissions.canWriteNonAssociation(prisoner, otherPrisoner)
+        },
+        [
+          ['Y', 'N', 'N', 'Y'],
+          [' ', 'N', 'N', 'N'],
+          [' ', ' ', 'N', 'N'],
+          [' ', ' ', ' ', 'Y'],
+        ],
+      )
+    })
+
+    describe('and allow prison users with global search and inactive bookings to modify non-associations in their caseloads, in transfer or outside', () => {
+      expectAllCombinations(
+        mockUser,
+        (permissions, prisoner, otherPrisoner) => {
+          return permissions.read && permissions.canWriteNonAssociation(prisoner, otherPrisoner)
+        },
+        [
+          ['Y', 'N', 'Y', 'Y'],
+          [' ', 'N', 'N', 'N'],
+          [' ', ' ', 'Y', 'Y'],
+          [' ', ' ', ' ', 'Y'],
+        ],
+      )
     })
   })
 })

--- a/server/middleware/userPermissions.test.ts
+++ b/server/middleware/userPermissions.test.ts
@@ -344,14 +344,14 @@ describe('userPermissions', () => {
   describe('should not allow modifying a non-association when', () => {
     it.each([
       {
-        scenario: 'key prisoner is not in your caseloads',
-        user: mockUser,
+        scenario: 'key prisoner is not in your caseloads if you don’t have global search',
+        user: mockUserWithoutGlobalSearch,
         prisoner: andrewBrown,
         otherPrisoner: davidJones,
       },
       {
-        scenario: 'other prisoner is not in your caseloads',
-        user: mockUser,
+        scenario: 'other prisoner is not in your caseloads if you don’t have global search',
+        user: mockUserWithoutGlobalSearch,
         prisoner: davidJones,
         otherPrisoner: andrewBrown,
       },
@@ -487,14 +487,14 @@ describe('userPermissions', () => {
       )
     })
 
-    describe('and allow prison users with global search to modify non-associations in their caseloads or in transfer', () => {
+    describe('and allow prison users with global search to modify non-associations in transfer or when at least one is in their caseloads', () => {
       expectAllCombinations(
         mockUserWithGlobalSearch,
         (permissions, prisoner, otherPrisoner) => {
           return permissions.read && permissions.canWriteNonAssociation(prisoner, otherPrisoner)
         },
         [
-          ['Y', 'N', 'Y', 'N'],
+          ['Y', 'Y', 'Y', 'N'],
           [' ', 'N', 'N', 'N'],
           [' ', ' ', 'Y', 'N'],
           [' ', ' ', ' ', 'N'],
@@ -517,14 +517,14 @@ describe('userPermissions', () => {
       )
     })
 
-    describe('and allow prison users with global search and inactive bookings to modify non-associations in their caseloads, in transfer or outside', () => {
+    describe('and allow prison users with global search and inactive bookings to modify non-associations in transfer, outside or when at least one is in their caseloads', () => {
       expectAllCombinations(
         mockUser,
         (permissions, prisoner, otherPrisoner) => {
           return permissions.read && permissions.canWriteNonAssociation(prisoner, otherPrisoner)
         },
         [
-          ['Y', 'N', 'Y', 'Y'],
+          ['Y', 'Y', 'Y', 'Y'],
           [' ', 'N', 'N', 'N'],
           [' ', ' ', 'Y', 'Y'],
           [' ', ' ', ' ', 'Y'],

--- a/server/middleware/userPermissions.ts
+++ b/server/middleware/userPermissions.ts
@@ -71,6 +71,9 @@ export class UserPermissions {
       return false
     }
 
+    const prisonerInCaseloads = this.caseloadSet.has(prisoner.prisonId)
+    const otherPrisonerInCaseloads = this.caseloadSet.has(otherPrisoner.prisonId)
+
     if (isBeingTransferred(prisoner)) {
       if (!this.globalSearch) {
         return false
@@ -79,8 +82,8 @@ export class UserPermissions {
       if (!this.inactiveBookings) {
         return false
       }
-    } else if (!this.caseloadSet.has(prisoner.prisonId)) {
-      return false
+    } else if (!prisonerInCaseloads) {
+      return this.globalSearch && otherPrisonerInCaseloads
     }
 
     if (isBeingTransferred(otherPrisoner)) {
@@ -91,8 +94,8 @@ export class UserPermissions {
       if (!this.inactiveBookings) {
         return false
       }
-    } else if (!this.caseloadSet.has(otherPrisoner.prisonId)) {
-      return false
+    } else if (!otherPrisonerInCaseloads) {
+      return this.globalSearch && prisonerInCaseloads
     }
 
     return true

--- a/server/middleware/userPermissions.ts
+++ b/server/middleware/userPermissions.ts
@@ -22,7 +22,7 @@ export class UserPermissions {
   public readonly write: boolean
 
   /**
-   * Can see prisoners in other prisons
+   * Can search for prisoners in other prisons
    */
   public readonly globalSearch: boolean
 

--- a/server/routes/prisonerSearch.ts
+++ b/server/routes/prisonerSearch.ts
@@ -187,6 +187,7 @@ export default function prisonerSearchRoutes(service: Services): Router {
         { text: 'Non-associations', href: service.routeUrls.list(prisonerNumber) },
       )
       res.render('pages/prisonerSearch.njk', {
+        prisoner,
         prisonName,
         prisonerNumber,
         prisonerName: nameOfPerson(prisoner),

--- a/server/routes/testutils/appSetup.ts
+++ b/server/routes/testutils/appSetup.ts
@@ -44,6 +44,11 @@ export const mockUser: Express.User = {
   roles: [userRolePrison, userRoleGlobalSearch, userRoleInactiveBookings, userRoleManageNonAssociations],
 }
 
+export const mockNonPrisonUser: Express.User = {
+  ...mockUser,
+  roles: [],
+}
+
 export const mockReadOnlyUser: Express.User = {
   ...mockUser,
   roles: [userRolePrison],
@@ -57,6 +62,11 @@ export const mockUserWithoutGlobalSearch: Express.User = {
 export const mockUserWithGlobalSearch: Express.User = {
   ...mockUser,
   roles: [userRolePrison, userRoleGlobalSearch, userRoleManageNonAssociations],
+}
+
+export const mockUserWithInactiveBookings: Express.User = {
+  ...mockUser,
+  roles: [userRolePrison, userRoleInactiveBookings, userRoleManageNonAssociations],
 }
 
 function appSetup(services: Services, production: boolean, userSupplier: () => Express.User): Express {

--- a/server/views/pages/prisonerSearch.njk
+++ b/server/views/pages/prisonerSearch.njk
@@ -111,7 +111,7 @@
             <a href="{{ routeUrls.view(prisonerNumber, openNonAssociationsMap.get(result.prisonerNumber)) }}">
               View non-association
             </a>
-          {% elif canViewProfile %}
+          {% elif user.permissions.canWriteNonAssociation(prisoner, result) %}
             <a href="{{ routeUrls.add(prisonerNumber, result.prisonerNumber) }}">
               Select prisoner
             </a>


### PR DESCRIPTION
…to allow users with “global search” to add/update/close non-associations between a prisoner in their caseloads and one in a prison outside their caseloads.

NB: The first commit doesn't change the rules, but simply adds tests to cover every combo of prisoner locations.

When checking roles and caseloads, the new rules are…
- forbid non-prison users from viewing or modifying any non-associations
- allow prison users to view all non-associations
- allow prison users to only modify non-associations in their caseloads
- allow prison users with global search to modify non-associations in transfer or when at least one is in their caseloads
- allow prison users with inactive bookings to modify non-associations in their caseloads or outside
- allow prison users with global search and inactive bookings to modify non-associations in transfer, outside or when at least one is in their caseloads