### PR TITLE
NON-287: Disallow adding a non-associations to prisoners with NO location

### DIFF
--- a/server/data/testData/offenderSearch.ts
+++ b/server/data/testData/offenderSearch.ts
@@ -80,13 +80,13 @@ export const joePeters: OffenderSearchResultOut = {
 }
 
 export const nathanLost: OffenderSearchResult = {
-  prisonId: '',
-  prisonName: '',
-  bookingId: 12350,
+  prisonId: undefined,
+  prisonName: undefined,
+  bookingId: undefined,
   prisonerNumber: 'D1234DD',
   firstName: 'NATHAN',
   lastName: 'LOST',
-  cellLocation: '',
+  cellLocation: undefined,
 }
 
 export const mockPrisoners = [davidJones, fredMills, oscarJones, andrewBrown, walterSmith, maxClarke, joePeters]

--- a/server/middleware/userPermissions.test.ts
+++ b/server/middleware/userPermissions.test.ts
@@ -5,19 +5,9 @@ import {
   userRoleGlobalSearch,
   userRoleInactiveBookings,
   userRoleManageNonAssociations,
-  transferPrisonId,
-  outsidePrisonId,
 } from '../data/constants'
 import type { OffenderSearchResult } from '../data/offenderSearch'
-import {
-  davidJones,
-  fredMills,
-  andrewBrown,
-  maxClarke,
-  joePeters,
-  nathanLost,
-  mockMovePrisoner,
-} from '../data/testData/offenderSearch'
+import { fredMills, andrewBrown, maxClarke, joePeters, nathanLost } from '../data/testData/offenderSearch'
 import {
   mockUser,
   mockNonPrisonUser,
@@ -25,71 +15,135 @@ import {
   mockUserWithoutGlobalSearch,
   mockUserWithGlobalSearch,
   mockUserWithInactiveBookings,
-  mockCaseloads,
 } from '../routes/testutils/appSetup'
-import userPermissions, { type UserPermissions } from './userPermissions'
+import userPermissions, { UserPermissions } from './userPermissions'
 
-function expectUser(user: Express.User) {
-  const req = jest.fn() as unknown as jest.Mocked<Request>
-  const res = jest.fn() as unknown as jest.Mocked<Response>
-  res.locals = {
-    breadcrumbs: undefined,
-    messages: {},
-    user,
-  } satisfies Express.Locals
-  const next = jest.fn() as unknown as jest.Mocked<NextFunction>
+type ExpectationRow<T> = readonly [T, T, T, T, T]
+type ExpectationGrid<T> = readonly [
+  ExpectationRow<T>,
+  ExpectationRow<T>,
+  ExpectationRow<T>,
+  ExpectationRow<T>,
+  ExpectationRow<T>,
+]
 
-  userPermissions()(req, res, next)
+class ExpectUser {
+  private readonly permissions: UserPermissions
 
-  expect(next).toHaveBeenCalled()
+  constructor(private user: Express.User) {
+    this.permissions = this.loadPermissionsViaMiddleware()
+  }
 
-  const { permissions } = res.locals.user
+  private loadPermissionsViaMiddleware(): UserPermissions {
+    const req = jest.fn() as unknown as jest.Mocked<Request>
+    const res = jest.fn() as unknown as jest.Mocked<Response>
+    res.locals = {
+      breadcrumbs: undefined,
+      messages: {},
+      user: this.user,
+    } satisfies Express.Locals
+    const next = jest.fn() as unknown as jest.Mocked<NextFunction>
 
-  return {
-    get permissions(): UserPermissions {
-      return permissions
-    },
+    userPermissions()(req, res, next)
 
-    toHavePermissionFlags(
-      flags: Pick<Express.User['permissions'], 'read' | 'write' | 'globalSearch' | 'inactiveBookings'>,
-    ): void {
-      expect(permissions).toEqual(expect.objectContaining(flags))
-    },
+    expect(next).toHaveBeenCalled()
+    const { permissions } = res.locals.user
+    expect(permissions).toBeInstanceOf(UserPermissions)
 
-    canViewPrisonerProfile(prisoner: OffenderSearchResult): void {
-      expect(permissions.canViewProfile(prisoner)).toEqual(true)
-    },
+    return permissions
+  }
 
-    cannotViewPrisonerProfile(prisoner: OffenderSearchResult): void {
-      expect(permissions.canViewProfile(prisoner)).toEqual(false)
-    },
+  toHavePermissionFlags(
+    flags: Pick<Express.User['permissions'], 'read' | 'write' | 'globalSearch' | 'inactiveBookings'>,
+  ): void {
+    expect(this.permissions).toEqual(expect.objectContaining(flags))
+  }
 
-    toHaveWritePermission(prisoner: OffenderSearchResult, otherPrisoner: OffenderSearchResult): void {
-      expect(permissions.canWriteNonAssociation(prisoner, otherPrisoner)).toEqual(true)
-    },
+  private forEachPrisonerLocation(
+    callback: (prisoner: OffenderSearchResult, prisonerLabel: string, index: number) => void,
+  ) {
+    const prisoners = [fredMills, andrewBrown, maxClarke, joePeters, nathanLost]
+    const prisonerLabels = [
+      'in caseloads',
+      'not in caseloads',
+      'being transferred',
+      'not in an establishment',
+      'with unknown location', // possibly doesn't even have a booking
+    ]
+    prisoners.forEach((prisoner, index) => {
+      const prisonerLabel = prisonerLabels[index]
+      callback(prisoner, prisonerLabel, index)
+    })
+  }
 
-    notToHaveWritePermission(prisoner: OffenderSearchResult, otherPrisoner: OffenderSearchResult): void {
-      expect(permissions.canWriteNonAssociation(prisoner, otherPrisoner)).toEqual(false)
-    },
+  private challengeWith1Prisoner(
+    challenge: (prisoner: OffenderSearchResult) => boolean,
+    expected: ExpectationRow<'Y' | 'N'>,
+  ) {
+    this.forEachPrisonerLocation((prisoner, prisonerLabel, rowIndex) => {
+      const expectedResult = expected[rowIndex] === 'Y'
+
+      it(`challenge for a prionser ${prisonerLabel} should be ${expectedResult}`, () => {
+        const result = challenge(prisoner)
+        expect(result).toEqual(expectedResult)
+      })
+    })
+  }
+
+  canViewSomePrisonerProfiles(expected: ExpectationRow<'Y' | 'N'>) {
+    this.challengeWith1Prisoner((prisoner: OffenderSearchResult) => {
+      return this.permissions.canViewProfile(prisoner)
+    }, expected)
+  }
+
+  private challengeWith2Prisoners(
+    challenge: (prisoner: OffenderSearchResult, otherPrisoner: OffenderSearchResult) => boolean,
+    // non-associations are symmetrical: ' ' means use inverse combination’s expected result
+    expected: ExpectationGrid<'Y' | 'N' | ' '>,
+  ) {
+    this.forEachPrisonerLocation((prisoner, prisonerLabel, rowIndex) => {
+      this.forEachPrisonerLocation((otherPrisoner, otherPrisonerLabel, columnIndex) => {
+        let expectation = expected[rowIndex][columnIndex]
+        if (expectation === ' ') {
+          expectation = expected[columnIndex][rowIndex]
+        }
+        const expectedResult = expectation === 'Y'
+
+        it(`challenge for a non-association between a prionser ${prisonerLabel} and a prisoner ${otherPrisonerLabel} should be ${expectedResult}`, () => {
+          const result = challenge(prisoner, otherPrisoner)
+          expect(result).toEqual(expectedResult)
+        })
+      })
+    })
+  }
+
+  cannotViewAnyNonAssociations() {
+    this.challengeWith2Prisoners(
+      () => this.permissions.read,
+      [
+        ['N', 'N', 'N', 'N', 'N'],
+        [' ', 'N', 'N', 'N', 'N'],
+        [' ', ' ', 'N', 'N', 'N'],
+        [' ', ' ', ' ', 'N', 'N'],
+        [' ', ' ', ' ', ' ', 'N'],
+      ],
+    )
+  }
+
+  canViewSomeNonAssociations(expected: ExpectationGrid<'Y' | 'N' | ' '>) {
+    this.challengeWith2Prisoners(() => this.permissions.read, expected)
+  }
+
+  canModifySomeNonAssociations(expected: ExpectationGrid<'Y' | 'N' | ' '>) {
+    this.challengeWith2Prisoners((prisoner, otherPrisoner) => {
+      return this.permissions.read && this.permissions.canWriteNonAssociation(prisoner, otherPrisoner)
+    }, expected)
   }
 }
 
-type ViewProfileScenarios = ReadonlyArray<{
-  scenario: string
-  user: Express.User
-  prisoner: OffenderSearchResult
-}>
-
-type HasWritePermissionScenarios = ReadonlyArray<{
-  scenario: string
-  user: Express.User
-  prisoner: OffenderSearchResult
-  otherPrisoner: OffenderSearchResult
-}>
-
 describe('userPermissions', () => {
   it('should set no read/write flags if the user is missing roles', () => {
-    expectUser(mockNonPrisonUser).toHavePermissionFlags({
+    new ExpectUser(mockNonPrisonUser).toHavePermissionFlags({
       read: false,
       write: false,
       globalSearch: false,
@@ -98,7 +152,7 @@ describe('userPermissions', () => {
   })
 
   it('should set read flag if user has necessary role', () => {
-    expectUser(mockReadOnlyUser).toHavePermissionFlags({
+    new ExpectUser(mockReadOnlyUser).toHavePermissionFlags({
       read: true,
       write: false,
       globalSearch: false,
@@ -107,7 +161,7 @@ describe('userPermissions', () => {
   })
 
   it('should set read & write flags if user has necessary roles', () => {
-    expectUser(mockUserWithoutGlobalSearch).toHavePermissionFlags({
+    new ExpectUser(mockUserWithoutGlobalSearch).toHavePermissionFlags({
       read: true,
       write: true,
       globalSearch: false,
@@ -116,7 +170,7 @@ describe('userPermissions', () => {
   })
 
   it('should set write flag only for prison users', () => {
-    expectUser({
+    new ExpectUser({
       ...mockUser,
       roles: [userRoleManageNonAssociations],
     }).toHavePermissionFlags({
@@ -129,7 +183,7 @@ describe('userPermissions', () => {
 
   describe('should set global search flag for users with necessary role', () => {
     it('if they have read permission', () => {
-      expectUser({
+      new ExpectUser({
         ...mockUser,
         roles: [userRolePrison, userRoleGlobalSearch],
       }).toHavePermissionFlags({
@@ -141,7 +195,7 @@ describe('userPermissions', () => {
     })
 
     it('if they also have write permission', () => {
-      expectUser(mockUserWithGlobalSearch).toHavePermissionFlags({
+      new ExpectUser(mockUserWithGlobalSearch).toHavePermissionFlags({
         read: true,
         write: true,
         globalSearch: true,
@@ -150,7 +204,7 @@ describe('userPermissions', () => {
     })
 
     it('but not if they don’t have read permission', () => {
-      expectUser({
+      new ExpectUser({
         ...mockUser,
         roles: [userRoleGlobalSearch],
       }).toHavePermissionFlags({
@@ -164,7 +218,7 @@ describe('userPermissions', () => {
 
   describe('should set inactive bookings flag for users with necessary role', () => {
     it('if they have read permission', () => {
-      expectUser({
+      new ExpectUser({
         ...mockUser,
         roles: [userRolePrison, userRoleInactiveBookings],
       }).toHavePermissionFlags({
@@ -176,7 +230,7 @@ describe('userPermissions', () => {
     })
 
     it('if they also have write permission', () => {
-      expectUser({
+      new ExpectUser({
         ...mockUser,
         roles: [userRolePrison, userRoleInactiveBookings, userRoleManageNonAssociations],
       }).toHavePermissionFlags({
@@ -188,7 +242,7 @@ describe('userPermissions', () => {
     })
 
     it('but not if they don’t have read permission', () => {
-      expectUser({
+      new ExpectUser({
         ...mockUser,
         roles: [userRoleInactiveBookings],
       }).toHavePermissionFlags({
@@ -201,7 +255,7 @@ describe('userPermissions', () => {
   })
 
   it('should set all flags for users with all necessary permissions', () => {
-    expectUser({
+    new ExpectUser({
       ...mockUser,
       roles: [userRolePrison, userRoleGlobalSearch, userRoleInactiveBookings, userRoleManageNonAssociations],
     }).toHavePermissionFlags({
@@ -212,345 +266,29 @@ describe('userPermissions', () => {
     })
   })
 
-  describe('should allow viewing a profile', () => {
-    it.each([
-      {
-        scenario: 'in your active caseload',
-        user: mockUser,
-        prisoner: davidJones,
-      },
-      {
-        scenario: 'in another of your caseloads',
-        user: {
-          ...mockUser,
-          caseloads: [...mockCaseloads, { id: 'LEI', name: 'Leeds (HMP)' }],
-        },
-        prisoner: andrewBrown,
-      },
-      {
-        scenario: 'of prisoners being transferred if you have global search',
-        user: mockUser,
-        prisoner: maxClarke,
-      },
-      {
-        scenario: 'of people not in an establishment if you have inactive bookings role',
-        user: mockUser,
-        prisoner: joePeters,
-      },
-    ] satisfies ViewProfileScenarios)('$scenario', ({ user, prisoner }) => {
-      expectUser(user).canViewPrisonerProfile(prisoner)
-    })
-  })
-
-  describe('should not allow viewing a profile', () => {
-    it.each([
-      {
-        scenario: 'not in your caseloads',
-        user: mockUser,
-        prisoner: andrewBrown,
-      },
-      {
-        scenario: 'of prisoners being transferred if you do not have global search',
-        user: {
-          ...mockUser,
-          roles: [userRolePrison, userRoleManageNonAssociations, userRoleInactiveBookings],
-        },
-        prisoner: maxClarke,
-      },
-      {
-        scenario: 'of people not in an establishment if you do not have inactive bookings role',
-        user: {
-          ...mockUser,
-          roles: [userRolePrison, userRoleManageNonAssociations, userRoleGlobalSearch],
-        },
-        prisoner: joePeters,
-      },
-      {
-        scenario: 'of people with unknown locations',
-        user: mockUser,
-        prisoner: nathanLost,
-      },
-    ] satisfies ViewProfileScenarios)('$scenario', ({ user, prisoner }) => {
-      expectUser(user).cannotViewPrisonerProfile(prisoner)
-    })
-  })
-
-  describe('should allow modifying a non-association between', () => {
-    it.each([
-      {
-        scenario: 'prisoners in your active caseload',
-        user: mockUser,
-        prisoner: davidJones,
-        otherPrisoner: fredMills,
-      },
-      {
-        scenario: 'prisoners in any of your caseloads',
-        user: {
-          ...mockUser,
-          caseloads: [...mockCaseloads, { id: 'LEI', name: 'Leeds (HMP)' }],
-        },
-        prisoner: davidJones,
-        otherPrisoner: andrewBrown,
-      },
-      {
-        scenario: 'a prisoner in your caseloads and another being transferred if you have global search',
-        user: mockUser,
-        prisoner: davidJones,
-        otherPrisoner: maxClarke,
-      },
-      {
-        scenario: 'a prisoner being transferred and another in your caseloads if you have global search',
-        user: mockUser,
-        prisoner: maxClarke,
-        otherPrisoner: davidJones,
-      },
-      {
-        scenario: 'prisoners being transferred if you have global search',
-        user: mockUser,
-        prisoner: maxClarke,
-        otherPrisoner: mockMovePrisoner(fredMills, transferPrisonId),
-      },
-      {
-        scenario:
-          'a prisoner in your caseloads and a person not in an establishment if you have inactive bookings role',
-        user: mockUser,
-        prisoner: fredMills,
-        otherPrisoner: joePeters,
-      },
-      {
-        scenario: 'a person not in an establishment and another in your caseloads if you have inactive bookings role',
-        user: mockUser,
-        prisoner: joePeters,
-        otherPrisoner: fredMills,
-      },
-      {
-        scenario: 'people not in establishments if you have inactive bookings role',
-        user: mockUser,
-        prisoner: joePeters,
-        otherPrisoner: mockMovePrisoner(fredMills, outsidePrisonId),
-      },
-      {
-        scenario: 'people being transferred and those not in establishments if you have necessary roles',
-        user: mockUser,
-        prisoner: maxClarke,
-        otherPrisoner: joePeters,
-      },
-      {
-        scenario:
-          'one permitted prisoner and themselves (used to check whether a non-association can potentially be added)',
-        user: mockUser,
-        prisoner: davidJones,
-        otherPrisoner: davidJones,
-      },
-    ] satisfies HasWritePermissionScenarios)('$scenario', ({ user, prisoner, otherPrisoner }) => {
-      expectUser(user).toHaveWritePermission(prisoner, otherPrisoner)
-    })
-  })
-
-  describe('should not allow modifying a non-association when', () => {
-    it.each([
-      {
-        scenario: 'key prisoner is not in your caseloads if you don’t have global search',
-        user: mockUserWithoutGlobalSearch,
-        prisoner: andrewBrown,
-        otherPrisoner: davidJones,
-      },
-      {
-        scenario: 'other prisoner is not in your caseloads if you don’t have global search',
-        user: mockUserWithoutGlobalSearch,
-        prisoner: davidJones,
-        otherPrisoner: andrewBrown,
-      },
-      {
-        scenario: 'key prisoner is being transferred and you do not have global search',
-        user: {
-          ...mockUser,
-          roles: [userRolePrison, userRoleManageNonAssociations, userRoleInactiveBookings],
-        },
-        prisoner: maxClarke,
-        otherPrisoner: davidJones,
-      },
-      {
-        scenario: 'other prisoner is being transferred and you do not have global search',
-        user: {
-          ...mockUser,
-          roles: [userRolePrison, userRoleManageNonAssociations, userRoleInactiveBookings],
-        },
-        prisoner: davidJones,
-        otherPrisoner: maxClarke,
-      },
-      {
-        scenario: 'key person is not in an establishment and you do not have inactive bookings role',
-        user: {
-          ...mockUser,
-          roles: [userRolePrison, userRoleManageNonAssociations, userRoleGlobalSearch],
-        },
-        prisoner: joePeters,
-        otherPrisoner: davidJones,
-      },
-      {
-        scenario: 'other person is not in an establishment and you do not have inactive bookings role',
-        user: {
-          ...mockUser,
-          roles: [userRolePrison, userRoleManageNonAssociations, userRoleGlobalSearch],
-        },
-        prisoner: davidJones,
-        otherPrisoner: joePeters,
-      },
-      {
-        scenario:
-          'both sides are one prisoner who is not permitted (used to check whether a non-association can potentially be added)',
-        user: mockUser,
-        prisoner: andrewBrown,
-        otherPrisoner: andrewBrown,
-      },
-      {
-        scenario: 'of people with unknown locations (possibly without even a booking)',
-        user: mockUser,
-        prisoner: nathanLost,
-        otherPrisoner: davidJones,
-      },
-    ] satisfies HasWritePermissionScenarios)('$scenario', ({ user, prisoner, otherPrisoner }) => {
-      expectUser(user).notToHaveWritePermission(prisoner, otherPrisoner)
-    })
-  })
-
   describe('should check roles and caseloads', () => {
-    const labels = [
-      'in caseloads',
-      'not in caseloads',
-      'being transferred',
-      'not in an establishment',
-      'with unknown location', // possibly doesn't even have a booking
-    ]
-    const prisoners = [fredMills, andrewBrown, maxClarke, joePeters, nathanLost]
-
-    type ExpectationRow<T> = readonly [T, T, T, T, T]
-    type ChallengeWith1Prisoner = (userPermissions: UserPermissions, prisoner: OffenderSearchResult) => boolean
-
-    function expectForPrisoners(
-      user: Express.User,
-      challenge: ChallengeWith1Prisoner,
-      expected: ExpectationRow<'Y' | 'N'>,
-    ) {
-      const { permissions } = expectUser(user)
-
-      prisoners.forEach((prisoner, rowIndex) => {
-        const prisonerLabel = labels[rowIndex]
-        const expectedResult = expected[rowIndex] === 'Y'
-
-        it(`challenge for a prionser ${prisonerLabel} should be ${expectedResult}`, () => {
-          const result = challenge(permissions, prisoner)
-          expect(result).toEqual(expectedResult)
-        })
-      })
-    }
-
     describe('and forbid non-prison users from viewing prisoner profiles', () => {
-      expectForPrisoners(
-        mockNonPrisonUser,
-        (permissions, prisoner) => {
-          return permissions.canViewProfile(prisoner)
-        },
-        ['N', 'N', 'N', 'N', 'N'],
-      )
+      new ExpectUser(mockNonPrisonUser).canViewSomePrisonerProfiles(['N', 'N', 'N', 'N', 'N'])
     })
 
     describe('and allow prison users to view profiles in their caseloads', () => {
-      expectForPrisoners(
-        mockReadOnlyUser,
-        (permissions, prisoner) => {
-          return permissions.canViewProfile(prisoner)
-        },
-        ['Y', 'N', 'N', 'N', 'N'],
-      )
+      new ExpectUser(mockReadOnlyUser).canViewSomePrisonerProfiles(['Y', 'N', 'N', 'N', 'N'])
     })
 
     describe('and allow prison users with global search to view profiles in their caseloads or in transfer', () => {
-      expectForPrisoners(
-        mockUserWithGlobalSearch,
-        (permissions, prisoner) => {
-          return permissions.canViewProfile(prisoner)
-        },
-        ['Y', 'N', 'Y', 'N', 'N'],
-      )
+      new ExpectUser(mockUserWithGlobalSearch).canViewSomePrisonerProfiles(['Y', 'N', 'Y', 'N', 'N'])
     })
 
     describe('and allow prison users with inactive bookings to view profiles in their caseloads or outside', () => {
-      expectForPrisoners(
-        mockUserWithInactiveBookings,
-        (permissions, prisoner) => {
-          return permissions.canViewProfile(prisoner)
-        },
-        ['Y', 'N', 'N', 'Y', 'N'],
-      )
+      new ExpectUser(mockUserWithInactiveBookings).canViewSomePrisonerProfiles(['Y', 'N', 'N', 'Y', 'N'])
     })
 
     describe('and allow prison users with global search and inactive bookings to view profiles in their caseloads, in transfer or outside', () => {
-      expectForPrisoners(
-        mockUser,
-        (permissions, prisoner) => {
-          return permissions.canViewProfile(prisoner)
-        },
-        ['Y', 'N', 'Y', 'Y', 'N'],
-      )
+      new ExpectUser(mockUser).canViewSomePrisonerProfiles(['Y', 'N', 'Y', 'Y', 'N'])
     })
 
-    type ExpectationGrid<T> = readonly [
-      ExpectationRow<T>,
-      ExpectationRow<T>,
-      ExpectationRow<T>,
-      ExpectationRow<T>,
-      ExpectationRow<T>,
-    ]
-    type ChallengeWith2Prisoners = (
-      userPermissions: UserPermissions,
-      prisoner: OffenderSearchResult,
-      otherPrisoner: OffenderSearchResult,
-    ) => boolean
-
-    function expectAllCombinationsWith2Prisoners(
-      user: Express.User,
-      challenge: ChallengeWith2Prisoners,
-      // non-associations are symmetrical: ' ' means use inverse combination’s expected result
-      expected: ExpectationGrid<'Y' | 'N' | ' '>,
-    ): void {
-      const { permissions } = expectUser(user)
-
-      prisoners.forEach((prisoner, rowIndex) => {
-        const prisonerLabel = labels[rowIndex]
-
-        prisoners.forEach((otherPrisoner, columnIndex) => {
-          const otherPrisonerLabel = labels[columnIndex]
-
-          let expectation = expected[rowIndex][columnIndex]
-          if (expectation === ' ') {
-            expectation = expected[columnIndex][rowIndex]
-          }
-          const expectedResult = expectation === 'Y'
-
-          it(`challenge for a non-association between a prionser ${prisonerLabel} and a prisoner ${otherPrisonerLabel} should be ${expectedResult}`, () => {
-            const result = challenge(permissions, prisoner, otherPrisoner)
-            expect(result).toEqual(expectedResult)
-          })
-        })
-      })
-    }
-
     describe('and forbid non-prison users from viewing or modifying any non-associations', () => {
-      expectAllCombinationsWith2Prisoners(
-        mockNonPrisonUser,
-        (permissions, prisoner, otherPrisoner) => {
-          return permissions.read || permissions.canWriteNonAssociation(prisoner, otherPrisoner)
-        },
-        [
-          ['N', 'N', 'N', 'N', 'N'],
-          [' ', 'N', 'N', 'N', 'N'],
-          [' ', ' ', 'N', 'N', 'N'],
-          [' ', ' ', ' ', 'N', 'N'],
-          [' ', ' ', ' ', ' ', 'N'],
-        ],
-      )
+      new ExpectUser(mockNonPrisonUser).cannotViewAnyNonAssociations()
     })
 
     describe('and allow prison users to view non-associations', () => {
@@ -561,7 +299,7 @@ describe('userPermissions', () => {
         mockUserWithInactiveBookings,
         mockUser,
       ]) {
-        expectAllCombinationsWith2Prisoners(user, permissions => permissions.read, [
+        new ExpectUser(user).canViewSomeNonAssociations([
           ['Y', 'Y', 'Y', 'Y', 'Y'],
           [' ', 'Y', 'Y', 'Y', 'Y'],
           [' ', ' ', 'Y', 'Y', 'Y'],
@@ -572,67 +310,43 @@ describe('userPermissions', () => {
     })
 
     describe('and allow prison users to only modify non-associations in their caseloads', () => {
-      expectAllCombinationsWith2Prisoners(
-        mockUserWithoutGlobalSearch,
-        (permissions, prisoner, otherPrisoner) => {
-          return permissions.read && permissions.canWriteNonAssociation(prisoner, otherPrisoner)
-        },
-        [
-          ['Y', 'N', 'N', 'N', 'N'],
-          [' ', 'N', 'N', 'N', 'N'],
-          [' ', ' ', 'N', 'N', 'N'],
-          [' ', ' ', ' ', 'N', 'N'],
-          [' ', ' ', ' ', ' ', 'N'],
-        ],
-      )
+      new ExpectUser(mockUserWithoutGlobalSearch).canModifySomeNonAssociations([
+        ['Y', 'N', 'N', 'N', 'N'],
+        [' ', 'N', 'N', 'N', 'N'],
+        [' ', ' ', 'N', 'N', 'N'],
+        [' ', ' ', ' ', 'N', 'N'],
+        [' ', ' ', ' ', ' ', 'N'],
+      ])
     })
 
     describe('and allow prison users with global search to modify non-associations in transfer or when at least one is in their caseloads', () => {
-      expectAllCombinationsWith2Prisoners(
-        mockUserWithGlobalSearch,
-        (permissions, prisoner, otherPrisoner) => {
-          return permissions.read && permissions.canWriteNonAssociation(prisoner, otherPrisoner)
-        },
-        [
-          ['Y', 'Y', 'Y', 'N', 'N'],
-          [' ', 'N', 'N', 'N', 'N'],
-          [' ', ' ', 'Y', 'N', 'N'],
-          [' ', ' ', ' ', 'N', 'N'],
-          [' ', ' ', ' ', ' ', 'N'],
-        ],
-      )
+      new ExpectUser(mockUserWithGlobalSearch).canModifySomeNonAssociations([
+        ['Y', 'Y', 'Y', 'N', 'N'],
+        [' ', 'N', 'N', 'N', 'N'],
+        [' ', ' ', 'Y', 'N', 'N'],
+        [' ', ' ', ' ', 'N', 'N'],
+        [' ', ' ', ' ', ' ', 'N'],
+      ])
     })
 
     describe('and allow prison users with inactive bookings to modify non-associations in their caseloads or outside', () => {
-      expectAllCombinationsWith2Prisoners(
-        mockUserWithInactiveBookings,
-        (permissions, prisoner, otherPrisoner) => {
-          return permissions.read && permissions.canWriteNonAssociation(prisoner, otherPrisoner)
-        },
-        [
-          ['Y', 'N', 'N', 'Y', 'N'],
-          [' ', 'N', 'N', 'N', 'N'],
-          [' ', ' ', 'N', 'N', 'N'],
-          [' ', ' ', ' ', 'Y', 'N'],
-          [' ', ' ', ' ', ' ', 'N'],
-        ],
-      )
+      new ExpectUser(mockUserWithInactiveBookings).canModifySomeNonAssociations([
+        ['Y', 'N', 'N', 'Y', 'N'],
+        [' ', 'N', 'N', 'N', 'N'],
+        [' ', ' ', 'N', 'N', 'N'],
+        [' ', ' ', ' ', 'Y', 'N'],
+        [' ', ' ', ' ', ' ', 'N'],
+      ])
     })
 
     describe('and allow prison users with global search and inactive bookings to modify non-associations in transfer, outside or when at least one is in their caseloads', () => {
-      expectAllCombinationsWith2Prisoners(
-        mockUser,
-        (permissions, prisoner, otherPrisoner) => {
-          return permissions.read && permissions.canWriteNonAssociation(prisoner, otherPrisoner)
-        },
-        [
-          ['Y', 'Y', 'Y', 'Y', 'N'],
-          [' ', 'N', 'N', 'N', 'N'],
-          [' ', ' ', 'Y', 'Y', 'N'],
-          [' ', ' ', ' ', 'Y', 'N'],
-          [' ', ' ', ' ', ' ', 'N'],
-        ],
-      )
+      new ExpectUser(mockUser).canModifySomeNonAssociations([
+        ['Y', 'Y', 'Y', 'Y', 'N'],
+        [' ', 'N', 'N', 'N', 'N'],
+        [' ', ' ', 'Y', 'Y', 'N'],
+        [' ', ' ', ' ', 'Y', 'N'],
+        [' ', ' ', ' ', ' ', 'N'],
+      ])
     })
   })
 })

--- a/server/middleware/userPermissions.test.ts
+++ b/server/middleware/userPermissions.test.ts
@@ -15,6 +15,7 @@ import {
   andrewBrown,
   maxClarke,
   joePeters,
+  nathanLost,
   mockMovePrisoner,
 } from '../data/testData/offenderSearch'
 import {
@@ -67,7 +68,7 @@ function expectUser(user: Express.User) {
       expect(permissions.canWriteNonAssociation(prisoner, otherPrisoner)).toEqual(true)
     },
 
-    toNotHaveWritePermission(prisoner: OffenderSearchResult, otherPrisoner: OffenderSearchResult): void {
+    notToHaveWritePermission(prisoner: OffenderSearchResult, otherPrisoner: OffenderSearchResult): void {
       expect(permissions.canWriteNonAssociation(prisoner, otherPrisoner)).toEqual(false)
     },
   }
@@ -264,6 +265,11 @@ describe('userPermissions', () => {
         },
         prisoner: joePeters,
       },
+      {
+        scenario: 'of people with unknown locations',
+        user: mockUser,
+        prisoner: nathanLost,
+      },
     ] satisfies ViewProfileScenarios)('$scenario', ({ user, prisoner }) => {
       expectUser(user).cannotViewPrisonerProfile(prisoner)
     })
@@ -398,18 +404,30 @@ describe('userPermissions', () => {
         prisoner: andrewBrown,
         otherPrisoner: andrewBrown,
       },
+      {
+        scenario: 'of people with unknown locations (possibly without even a booking)',
+        user: mockUser,
+        prisoner: nathanLost,
+        otherPrisoner: davidJones,
+      },
     ] satisfies HasWritePermissionScenarios)('$scenario', ({ user, prisoner, otherPrisoner }) => {
-      expectUser(user).toNotHaveWritePermission(prisoner, otherPrisoner)
+      expectUser(user).notToHaveWritePermission(prisoner, otherPrisoner)
     })
   })
 
   describe('should check roles and caseloads', () => {
-    const labels = ['in caseloads', 'not in caseloads', 'being transferred', 'not in an establishment']
-    const prisoners = [fredMills, andrewBrown, maxClarke, joePeters]
+    const labels = [
+      'in caseloads',
+      'not in caseloads',
+      'being transferred',
+      'not in an establishment',
+      'with no location',
+    ]
+    const prisoners = [fredMills, andrewBrown, maxClarke, joePeters, nathanLost]
 
     type Expected = 'Y' | 'N' | ' '
-    type ExpectationRow = readonly [Expected, Expected, Expected, Expected]
-    type ExpectationTable = readonly [ExpectationRow, ExpectationRow, ExpectationRow, ExpectationRow]
+    type ExpectationRow = readonly [Expected, Expected, Expected, Expected, Expected]
+    type ExpectationTable = readonly [ExpectationRow, ExpectationRow, ExpectationRow, ExpectationRow, ExpectationRow]
     type Challenge = (
       userPermissions: UserPermissions,
       prisoner: OffenderSearchResult,
@@ -447,10 +465,11 @@ describe('userPermissions', () => {
           return permissions.read || permissions.canWriteNonAssociation(prisoner, otherPrisoner)
         },
         [
-          ['N', 'N', 'N', 'N'],
-          [' ', 'N', 'N', 'N'],
-          [' ', ' ', 'N', 'N'],
-          [' ', ' ', ' ', 'N'],
+          ['N', 'N', 'N', 'N', 'N'],
+          [' ', 'N', 'N', 'N', 'N'],
+          [' ', ' ', 'N', 'N', 'N'],
+          [' ', ' ', ' ', 'N', 'N'],
+          [' ', ' ', ' ', ' ', 'N'],
         ],
       )
     })
@@ -464,10 +483,11 @@ describe('userPermissions', () => {
         mockUser,
       ]) {
         expectAllCombinations(user, permissions => permissions.read, [
-          ['Y', 'Y', 'Y', 'Y'],
-          [' ', 'Y', 'Y', 'Y'],
-          [' ', ' ', 'Y', 'Y'],
-          [' ', ' ', ' ', 'Y'],
+          ['Y', 'Y', 'Y', 'Y', 'Y'],
+          [' ', 'Y', 'Y', 'Y', 'Y'],
+          [' ', ' ', 'Y', 'Y', 'Y'],
+          [' ', ' ', ' ', 'Y', 'Y'],
+          [' ', ' ', ' ', ' ', 'Y'],
         ])
       }
     })
@@ -479,10 +499,11 @@ describe('userPermissions', () => {
           return permissions.read && permissions.canWriteNonAssociation(prisoner, otherPrisoner)
         },
         [
-          ['Y', 'N', 'N', 'N'],
-          [' ', 'N', 'N', 'N'],
-          [' ', ' ', 'N', 'N'],
-          [' ', ' ', ' ', 'N'],
+          ['Y', 'N', 'N', 'N', 'N'],
+          [' ', 'N', 'N', 'N', 'N'],
+          [' ', ' ', 'N', 'N', 'N'],
+          [' ', ' ', ' ', 'N', 'N'],
+          [' ', ' ', ' ', ' ', 'N'],
         ],
       )
     })
@@ -494,10 +515,11 @@ describe('userPermissions', () => {
           return permissions.read && permissions.canWriteNonAssociation(prisoner, otherPrisoner)
         },
         [
-          ['Y', 'Y', 'Y', 'N'],
-          [' ', 'N', 'N', 'N'],
-          [' ', ' ', 'Y', 'N'],
-          [' ', ' ', ' ', 'N'],
+          ['Y', 'Y', 'Y', 'N', 'N'],
+          [' ', 'N', 'N', 'N', 'N'],
+          [' ', ' ', 'Y', 'N', 'N'],
+          [' ', ' ', ' ', 'N', 'N'],
+          [' ', ' ', ' ', ' ', 'N'],
         ],
       )
     })
@@ -509,10 +531,11 @@ describe('userPermissions', () => {
           return permissions.read && permissions.canWriteNonAssociation(prisoner, otherPrisoner)
         },
         [
-          ['Y', 'N', 'N', 'Y'],
-          [' ', 'N', 'N', 'N'],
-          [' ', ' ', 'N', 'N'],
-          [' ', ' ', ' ', 'Y'],
+          ['Y', 'N', 'N', 'Y', 'N'],
+          [' ', 'N', 'N', 'N', 'N'],
+          [' ', ' ', 'N', 'N', 'N'],
+          [' ', ' ', ' ', 'Y', 'N'],
+          [' ', ' ', ' ', ' ', 'N'],
         ],
       )
     })
@@ -524,10 +547,11 @@ describe('userPermissions', () => {
           return permissions.read && permissions.canWriteNonAssociation(prisoner, otherPrisoner)
         },
         [
-          ['Y', 'Y', 'Y', 'Y'],
-          [' ', 'N', 'N', 'N'],
-          [' ', ' ', 'Y', 'Y'],
-          [' ', ' ', ' ', 'Y'],
+          ['Y', 'Y', 'Y', 'Y', 'N'],
+          [' ', 'N', 'N', 'N', 'N'],
+          [' ', ' ', 'Y', 'Y', 'N'],
+          [' ', ' ', ' ', 'Y', 'N'],
+          [' ', ' ', ' ', ' ', 'N'],
         ],
       )
     })

--- a/server/middleware/userPermissions.ts
+++ b/server/middleware/userPermissions.ts
@@ -71,6 +71,10 @@ export class UserPermissions {
       return false
     }
 
+    if (!prisoner.prisonId || !otherPrisoner.prisonId) {
+      return false
+    }
+
     const prisonerInCaseloads = this.caseloadSet.has(prisoner.prisonId)
     const otherPrisonerInCaseloads = this.caseloadSet.has(otherPrisoner.prisonId)
 

--- a/server/middleware/userPermissions.ts
+++ b/server/middleware/userPermissions.ts
@@ -52,6 +52,12 @@ export class UserPermissions {
    * Whether prisoner photos and links to their profiles should show
    */
   canViewProfile(prisoner: { prisonId: string }): boolean {
+    if (!this.read) {
+      return false
+    }
+    if (!prisoner.prisonId) {
+      return false
+    }
     if (isBeingTransferred(prisoner)) {
       return this.user.permissions.globalSearch
     }


### PR DESCRIPTION
This allegedly indicates they have no booking.

Related: [api#152](https://github.com/ministryofjustice/hmpps-non-associations-api/pull/152)