### PR TITLE
NON-303: Stop non-prod instances during non-working hours

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -2,6 +2,9 @@
 generic-service:
   replicaCount: 2
 
+  scheduledDowntime:
+    enabled: true
+
   ingress:
     host: non-associations-dev.hmpps.service.justice.gov.uk
 

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -2,6 +2,9 @@
 generic-service:
   replicaCount: 2
 
+  scheduledDowntime:
+    enabled: true
+
   ingress:
     host: non-associations-preprod.hmpps.service.justice.gov.uk
 


### PR DESCRIPTION
Enable 'scheduled downtime' feature of generic-service helm chart: https://github.com/ministryofjustice/hmpps-helm-charts/tree/main/charts/generic-service#scheduled-downtime

> To enable this feature, you first need to add a `scheduled-downtime-serviceaccount`
> Service Account to your namespace, with permissions to scale your deployment.

The required kubernetes `ServiceAccount` is already there:
- `dev`: https://github.com/ministryofjustice/cloud-platform-environments/blob/ed74f5b567c5e8e2f2aab90a92263f23021ca106/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-dev/resources/scheduled-downtime.tf
- `preprod`: https://github.com/ministryofjustice/cloud-platform-environments/blob/ed74f5b567c5e8e2f2aab90a92263f23021ca106/namespaces/live.cloud-platform.service.justice.gov.uk/hmpps-non-associations-preprod/resources/scheduled-downtime.tf

```sh
$ kubectl -n hmpps-non-associations-dev get sa scheduled-downtime-serviceaccount
NAME                                SECRETS   AGE
scheduled-downtime-serviceaccount   2         165d
```

```sh
$ kubectl -n hmpps-non-associations-preprod get sa scheduled-downtime-serviceaccount
NAME                                SECRETS   AGE
scheduled-downtime-serviceaccount   2         140d
```