### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@7.5
+  hmpps: ministryofjustice/hmpps@7
   slack: circleci/slack@4.12.5
 
 parameters:
@@ -44,7 +44,8 @@ jobs:
       - run:
           name: Build application
           command: npm run build
-      - run: # Run linter after build because the integration test code depend on compiled typescript...
+      - run:
+          # Run linter after build because the integration test code depend on compiled typescript...
           name: Linter check
           command: npm run lint
       - persist_to_workspace:

--- a/helm_deploy/hmpps-non-associations/Chart.yaml
+++ b/helm_deploy/hmpps-non-associations/Chart.yaml
@@ -4,9 +4,15 @@ description: A Helm chart for Kubernetes
 name: hmpps-non-associations
 version: 0.2.0
 dependencies:
-  - name: generic-service
-    version: 2.8.1
-    repository: https://ministryofjustice.github.io/hmpps-helm-charts
-  - name: generic-prometheus-alerts
-    version: 1.3.3
-    repository: https://ministryofjustice.github.io/hmpps-helm-charts
+  - "name": |-
+      generic-service
+    "version": |-
+      2.8
+    "repository": |-
+      https://ministryofjustice.github.io/hmpps-helm-charts
+  - "name": |-
+      generic-prometheus-alerts
+    "version": |-
+      1.3.3
+    "repository": |-
+      https://ministryofjustice.github.io/hmpps-helm-charts

--- a/helm_deploy/hmpps-non-associations/values.yaml
+++ b/helm_deploy/hmpps-non-associations/values.yaml
@@ -1,4 +1,3 @@
----
 generic-service:
   nameOverride: hmpps-non-associations
   productId: DPS032
@@ -7,14 +6,14 @@ generic-service:
 
   image:
     repository: quay.io/hmpps/hmpps-non-associations
-    tag: app_version    # override at deployment time
+    tag: app_version # override at deployment time
     port: 3000
 
   ingress:
     enabled: true
-    host: app-hostname.local    # override per environment
+    host: app-hostname.local # override per environment
     tlsSecretName: hmpps-non-associations-cert
-    modsecurity_enabled: true  # enable OWASP core rules then handle false positives by removing or tweaking rules to not block specific args or cookies
+    modsecurity_enabled: true # enable OWASP core rules then handle false positives by removing or tweaking rules to not block specific args or cookies
     modsecurity_audit_enabled: false
     modsecurity_snippet: |
       SecRuleEngine On
@@ -81,10 +80,9 @@ generic-service:
       REDIS_AUTH_TOKEN: "auth_token"
 
   allowlist:
-    groups:
-      - internal
-      - prisons
-      - private_prisons
+    "undefined": |-
+      internal,prisons,private_prisons/32
+    "groups": []
 
 generic-prometheus-alerts:
   targetApplication: hmpps-non-associations


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

1 allowlist(s) have been detected that can be migrated.



## Allowlist: helm_deploy/hmpps-non-associations/values.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: ``
- The size of the allowlist defined in this file will change: `1 => 1 (0 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:

  Merging this PR should not result in any additional IP addresses being added to the allowlist.

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:

  **No IPs have been identified for removal**
  
