### PR TITLE
NON-337: Relax role-based restrictions

### DIFF
--- a/server/middleware/userPermissions.test.ts
+++ b/server/middleware/userPermissions.test.ts
@@ -322,7 +322,7 @@ describe('userPermissions', () => {
 
     describe('and allow prison users to only modify non-associations in their caseloads', () => {
       new ExpectUser(mockUserWithoutGlobalSearch).canModifySomeNonAssociations([
-        ['Y', 'N', 'N', 'N', 'N'],
+        ['Y', 'Y', 'Y', 'Y', 'N'],
         [' ', 'N', 'N', 'N', 'N'],
         [' ', ' ', 'N', 'N', 'N'],
         [' ', ' ', ' ', 'N', 'N'],
@@ -332,7 +332,7 @@ describe('userPermissions', () => {
 
     describe('and allow prison users with global search to modify non-associations in transfer or when at least one is in their caseloads', () => {
       new ExpectUser(mockUserWithGlobalSearch).canModifySomeNonAssociations([
-        ['Y', 'Y', 'Y', 'N', 'N'],
+        ['Y', 'Y', 'Y', 'Y', 'N'],
         [' ', 'N', 'N', 'N', 'N'],
         [' ', ' ', 'Y', 'N', 'N'],
         [' ', ' ', ' ', 'N', 'N'],
@@ -342,7 +342,7 @@ describe('userPermissions', () => {
 
     describe('and allow prison users with inactive bookings to modify non-associations in their caseloads or outside', () => {
       new ExpectUser(mockUserWithInactiveBookings).canModifySomeNonAssociations([
-        ['Y', 'N', 'N', 'Y', 'N'],
+        ['Y', 'Y', 'Y', 'Y', 'N'],
         [' ', 'N', 'N', 'N', 'N'],
         [' ', ' ', 'N', 'N', 'N'],
         [' ', ' ', ' ', 'Y', 'N'],

--- a/server/middleware/userPermissions.ts
+++ b/server/middleware/userPermissions.ts
@@ -89,6 +89,11 @@ export class UserPermissions {
 
     const prisonerInCaseloads = this.caseloadSet.has(prisoner.prisonId)
     const otherPrisonerInCaseloads = this.caseloadSet.has(otherPrisoner.prisonId)
+    const eitherPrisonerInCaseloads = prisonerInCaseloads || otherPrisonerInCaseloads
+
+    if (eitherPrisonerInCaseloads) {
+      return true
+    }
 
     if (isBeingTransferred(prisoner)) {
       if (!this.globalSearch) {

--- a/server/routes/add.test.ts
+++ b/server/routes/add.test.ts
@@ -9,7 +9,14 @@ import { userRolePrison, userRoleInactiveBookings, userRoleManageNonAssociations
 import { NonAssociationsApi } from '../data/nonAssociationsApi'
 import { OffenderSearchClient } from '../data/offenderSearch'
 import { mockNonAssociation } from '../data/testData/nonAssociationsApi'
-import { davidJones, fredMills, maxClarke, joePeters, mockGetPrisoner } from '../data/testData/offenderSearch'
+import {
+  davidJones,
+  fredMills,
+  andrewBrown,
+  maxClarke,
+  joePeters,
+  mockGetPrisoner,
+} from '../data/testData/offenderSearch'
 
 jest.mock('@ministryofjustice/hmpps-non-associations-api', () => {
   // ensures that constants are preserved
@@ -58,19 +65,19 @@ describe('Add non-association details page', () => {
       otherPrisoner: fredMills,
     },
     {
-      scenario: 'is missing global search',
+      scenario: 'is missing global search and neither prisoner is in caseloads',
       user: {
         ...mockUser,
         roles: [userRolePrison, userRoleInactiveBookings, userRoleManageNonAssociations],
       },
-      prisoner: davidJones,
+      prisoner: andrewBrown,
       otherPrisoner: maxClarke,
     },
     {
-      scenario: 'is missing inactive bookings role',
+      scenario: 'is missing inactive bookings role and neither prisoner is in caseloads',
       user: mockUserWithGlobalSearch,
       prisoner: joePeters,
-      otherPrisoner: davidJones,
+      otherPrisoner: andrewBrown,
     },
   ])('should return 404 if user $scenario', ({ user, prisoner: p1, otherPrisoner: p2 }) => {
     app = appWithAllRoutes({

--- a/server/routes/close.test.ts
+++ b/server/routes/close.test.ts
@@ -8,7 +8,7 @@ import { userRolePrison, userRoleInactiveBookings, userRoleManageNonAssociations
 import { NonAssociationsApi } from '../data/nonAssociationsApi'
 import { OffenderSearchClient } from '../data/offenderSearch'
 import { mockNonAssociation } from '../data/testData/nonAssociationsApi'
-import { davidJones, fredMills, oscarJones, maxClarke, joePeters } from '../data/testData/offenderSearch'
+import { davidJones, fredMills, oscarJones, andrewBrown, maxClarke, joePeters } from '../data/testData/offenderSearch'
 
 jest.mock('@ministryofjustice/hmpps-non-associations-api', () => {
   // ensures that constants are preserved
@@ -58,20 +58,20 @@ describe('Close non-association page', () => {
       expectEarly404: true,
     },
     {
-      scenario: 'is missing global search',
+      scenario: 'is missing global search and neither prisoner is in caseloads',
       user: {
         ...mockUser,
         roles: [userRolePrison, userRoleInactiveBookings, userRoleManageNonAssociations],
       },
-      prisoner: davidJones,
+      prisoner: andrewBrown,
       otherPrisoner: maxClarke,
       expectEarly404: false,
     },
     {
-      scenario: 'is missing inactive bookings role',
+      scenario: 'is missing inactive bookings role and neither prisoner is in caseloads',
       user: mockUserWithGlobalSearch,
       prisoner: joePeters,
-      otherPrisoner: davidJones,
+      otherPrisoner: andrewBrown,
       expectEarly404: false,
     },
   ])('should return 404 if user $scenario', ({ user, prisoner: p1, otherPrisoner: p2, expectEarly404 }) => {

--- a/server/routes/prisonerSearch.test.ts
+++ b/server/routes/prisonerSearch.test.ts
@@ -279,7 +279,7 @@ describe('Search for a prisoner page', () => {
         expect(filters.lastName).toEqual('Smith')
         expect(filters.firstName).toBeUndefined()
         expect(filters.prisonerIdentifier).toBeUndefined()
-        expect(filters.location).toEqual('IN')
+        expect(filters.location).toEqual('ALL')
         expect(filters.includeAliases).toEqual(true)
         expect(page).toEqual(0) // NB: page is 0-indexed in offender search
         expect(offenderSearchClient.searchInPrison).not.toHaveBeenCalled()

--- a/server/routes/prisonerSearch.test.ts
+++ b/server/routes/prisonerSearch.test.ts
@@ -140,24 +140,6 @@ describe('Search for a prisoner page', () => {
       })
   })
 
-  it('should not show radio buttons to select scope if user doesn’t have global search', () => {
-    app = appWithAllRoutes({
-      userSupplier: () => mockUserWithoutGlobalSearch,
-    })
-    offenderSearchClient.getPrisoner.mockResolvedValueOnce(prisoner)
-
-    return request(app)
-      .get(routeUrls.prisonerSearch(prisonerNumber))
-      .expect(200)
-      .expect(res => {
-        expect(res.text).not.toContain('In Moorland')
-        expect(res.text).not.toContain('In any establishment (global)')
-        // search not performed
-        expect(offenderSearchClient.searchInPrison).not.toHaveBeenCalled()
-        expect(offenderSearchClient.searchGlobally).not.toHaveBeenCalled()
-      })
-  })
-
   it.each([
     {
       scenario: 'global search',

--- a/server/routes/prisonerSearch.test.ts
+++ b/server/routes/prisonerSearch.test.ts
@@ -67,7 +67,7 @@ describe('Search for a prisoner page', () => {
       prisoner: davidJones,
     },
     {
-      scenario: 'is missing global search',
+      scenario: 'is missing global search and key prisoner is not in caseloads',
       user: {
         ...mockUser,
         roles: [userRolePrison, userRoleInactiveBookings, userRoleManageNonAssociations],
@@ -75,7 +75,7 @@ describe('Search for a prisoner page', () => {
       prisoner: maxClarke,
     },
     {
-      scenario: 'is missing inactive bookings role',
+      scenario: 'is missing inactive bookings role and key prisoner is not in caseloads',
       user: mockUserWithGlobalSearch,
       prisoner: joePeters,
     },

--- a/server/routes/prisonerSearch.ts
+++ b/server/routes/prisonerSearch.ts
@@ -67,8 +67,7 @@ export default function prisonerSearchRoutes(service: Services): Router {
           `User ${user.username} does not have permissions to add non-associations for ${prisonerNumber}`,
         )
       }
-      const hasGlobalSearch = user.permissions.globalSearch
-      const hasGlobalSearchAndInactiveBookings = hasGlobalSearch && user.permissions.inactiveBookings
+      const hasInactiveBookings = user.permissions.inactiveBookings
 
       const form: PrisonerSearchForm | null = res.locals.submittedForm
 
@@ -85,10 +84,10 @@ export default function prisonerSearchRoutes(service: Services): Router {
         const order = form.fields.order.value
 
         let response: OffenderSearchResults
-        const globalSearch = hasGlobalSearch && scope === 'global'
+        const globalSearch = scope === 'global'
         if (globalSearch) {
           const filters: Parameters<OffenderSearchClient['searchGlobally']>[0] = {
-            location: hasGlobalSearchAndInactiveBookings ? 'ALL' : 'IN',
+            location: hasInactiveBookings ? 'ALL' : 'IN',
             includeAliases: true,
           }
           if (/\d/.test(searchTerms)) {
@@ -197,7 +196,6 @@ export default function prisonerSearchRoutes(service: Services): Router {
         openNonAssociationsMap,
         tableHead,
         paginationParams,
-        hasGlobalSearch,
       })
     }),
   )

--- a/server/routes/prisonerSearch.ts
+++ b/server/routes/prisonerSearch.ts
@@ -67,7 +67,6 @@ export default function prisonerSearchRoutes(service: Services): Router {
           `User ${user.username} does not have permissions to add non-associations for ${prisonerNumber}`,
         )
       }
-      const hasInactiveBookings = user.permissions.inactiveBookings
 
       const form: PrisonerSearchForm | null = res.locals.submittedForm
 
@@ -87,7 +86,7 @@ export default function prisonerSearchRoutes(service: Services): Router {
         const globalSearch = scope === 'global'
         if (globalSearch) {
           const filters: Parameters<OffenderSearchClient['searchGlobally']>[0] = {
-            location: hasInactiveBookings ? 'ALL' : 'IN',
+            location: 'ALL',
             includeAliases: true,
           }
           if (/\d/.test(searchTerms)) {

--- a/server/routes/update.test.ts
+++ b/server/routes/update.test.ts
@@ -8,7 +8,7 @@ import { userRolePrison, userRoleInactiveBookings, userRoleManageNonAssociations
 import { NonAssociationsApi } from '../data/nonAssociationsApi'
 import { OffenderSearchClient, type OffenderSearchResult } from '../data/offenderSearch'
 import { mockNonAssociation } from '../data/testData/nonAssociationsApi'
-import { davidJones, fredMills, oscarJones, maxClarke, joePeters } from '../data/testData/offenderSearch'
+import { davidJones, fredMills, oscarJones, andrewBrown, maxClarke, joePeters } from '../data/testData/offenderSearch'
 
 jest.mock('@ministryofjustice/hmpps-non-associations-api', () => {
   // ensures that constants are preserved
@@ -61,20 +61,20 @@ describe('Update non-association page', () => {
       expectEarly404: true,
     },
     {
-      scenario: 'is missing global search',
+      scenario: 'is missing global search and neither prisoner is in caseloads',
       user: {
         ...mockUser,
         roles: [userRolePrison, userRoleInactiveBookings, userRoleManageNonAssociations],
       },
-      prisoner: davidJones,
+      prisoner: andrewBrown,
       otherPrisoner: maxClarke,
       expectEarly404: false,
     },
     {
-      scenario: 'is missing inactive bookings role',
+      scenario: 'is missing inactive bookings role and neither prisoner is in caseloads',
       user: mockUserWithGlobalSearch,
       prisoner: joePeters,
-      otherPrisoner: davidJones,
+      otherPrisoner: andrewBrown,
       expectEarly404: false,
     },
   ])('should return 404 if user $scenario', ({ user, prisoner: p1, otherPrisoner: p2, expectEarly404 }) => {

--- a/server/routes/view.test.ts
+++ b/server/routes/view.test.ts
@@ -384,17 +384,19 @@ describe('View non-association details page', () => {
         nonAssociation,
       },
       {
-        scenario: 'a prisoner is being transferred but you do not have global search',
+        scenario:
+          'a prisoner is being transferred but you do not have global search whilst the other is not in your caseloads',
         user: {
           ...mockUser,
           roles: [userRolePrison, userRoleInactiveBookings, userRoleManageNonAssociations],
         },
-        nonAssociation: mockNonAssociation(davidJones.prisonerNumber, maxClarke.prisonerNumber),
+        nonAssociation: mockNonAssociation(andrewBrown.prisonerNumber, maxClarke.prisonerNumber),
       },
       {
-        scenario: 'a person is not in an establishment but you do not have inactive bookings role',
+        scenario:
+          'a person is not in an establishment but you do not have inactive bookings role whilst the other is not in your caseloads',
         user: mockUserWithGlobalSearch,
-        nonAssociation: mockNonAssociation(joePeters.prisonerNumber, davidJones.prisonerNumber),
+        nonAssociation: mockNonAssociation(joePeters.prisonerNumber, andrewBrown.prisonerNumber),
       },
     ])('$scenario', ({ user, nonAssociation: na }) => {
       app = appWithAllRoutes({

--- a/server/views/pages/prisonerSearch.njk
+++ b/server/views/pages/prisonerSearch.njk
@@ -14,34 +14,31 @@
   <h1 class="govuk-heading-l">Search for a prisoner to keep apart from {{ prisonerName }}</h1>
 
   <form method="get" novalidate>
-    {% if hasGlobalSearch %}
-      {% set fieldId = "scope" %}
-      {% set field = form.fields[fieldId] %}
-      {{ govukRadios({
-        attributes: { id: formId + "-" + fieldId },
-        classes: "govuk-radios--inline govuk-radios--small",
-        name: fieldId,
-        fieldset: {
-          legend: {
-            text: "Search for prisoners",
-            classes: "govuk-visually-hidden"
-          }
-        },
-        items: [
-          {value: "prison", text: "In " + prisonName},
-          {value: "global", text: "In any establishment (global)"}
-        ] | checkedItems(field.value if field.value else "prison"),
-        errorMessage: { text: field.error } if field.error else undefined
-      }) }}
-    {% endif %}
+    {% set fieldId = "scope" %}
+    {% set field = form.fields[fieldId] %}
+    {{ govukRadios({
+      attributes: { id: formId + "-" + fieldId },
+      classes: "govuk-radios--inline govuk-radios--small",
+      name: fieldId,
+      fieldset: {
+        legend: {
+          text: "Search for prisoners",
+          classes: "govuk-visually-hidden"
+        }
+      },
+      items: [
+        {value: "prison", text: "In " + prisonName},
+        {value: "global", text: "In any establishment (global)"}
+      ] | checkedItems(field.value if field.value else "prison"),
+      errorMessage: { text: field.error } if field.error else undefined
+    }) }}
 
     <div class="app-prisoner-search-form govuk-!-margin-bottom-3">
       {% set fieldId = "q" %}
       {% set field = form.fields[fieldId] %}
       {{ govukInput({
         label: {
-          text: "Name or prison number" if hasGlobalSearch else "Enter name or prison number",
-          classes: "" if hasGlobalSearch else "govuk-label--m"
+          text: "Name or prison number"
         },
         id: formId + "-" + fieldId,
         name: fieldId,


### PR DESCRIPTION
… so that if a prisoner is in your caseloads, it doesn't matter if the other is being transferred or has been released – global search and inactive bookings roles aren't required to add/update/close non-associations. Which means that the prisoner search page no longer needs the variation that searches only in the current caseload.