### PR TITLE
NON-340: Fix display of email address in help-with-roles message

### DIFF
--- a/server/views/pages/list.njk
+++ b/server/views/pages/list.njk
@@ -121,7 +121,7 @@
       <div class="govuk-grid-column-two-thirds">
         {{ govukDetails({
           summaryText: "Need to add non-associations?",
-          html: helpWithRoles()
+          html: helpWithRoles(teamEmail)
         }) }}
       </div>
     </div>

--- a/server/views/pages/view.njk
+++ b/server/views/pages/view.njk
@@ -101,7 +101,7 @@
           <div class="govuk-!-margin-top-6 govuk-!-display-none-print">
             {{ govukDetails({
               summaryText: "Need to update non-associations?",
-              html: helpWithRoles()
+              html: helpWithRoles(teamEmail)
             }) }}
           </div>
         {% endif %}

--- a/server/views/partials/helpWithRoles.njk
+++ b/server/views/partials/helpWithRoles.njk
@@ -1,4 +1,4 @@
-{% macro helpWithRoles() %}
+{% macro helpWithRoles(teamEmail) %}
 
   <p>
     Ask your local system administrator (LSA) to add the ‘Non-associations’ role to your account.


### PR DESCRIPTION
Macros do not inherit global context so email variable needs to be passed in