### PR TITLE
NON-347: Updated DPR and removed now unnecessary CSP config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-sqs": "^3.540.0",
         "@ministryofjustice/frontend": "^2.1.2",
-        "@ministryofjustice/hmpps-digital-prison-reporting-frontend": "^3.7.0",
+        "@ministryofjustice/hmpps-digital-prison-reporting-frontend": "^3.7.2",
         "@ministryofjustice/hmpps-non-associations-api": "https://github.com/ministryofjustice/hmpps-non-associations-api/releases/download/node-client-0.4.0/node-client.tgz",
         "agentkeepalive": "^4.5.0",
         "applicationinsights": "^2.9.5",
@@ -2169,9 +2169,9 @@
       }
     },
     "node_modules/@ministryofjustice/hmpps-digital-prison-reporting-frontend": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-digital-prison-reporting-frontend/-/hmpps-digital-prison-reporting-frontend-3.7.0.tgz",
-      "integrity": "sha512-en0AhTCWVjWGK/+klt3msFe6LefI2X0zUz1QkwnHLxPu4ljNqhyDGV81sv60Tf4PYEovMVzUe0R//BlpXQLWEA==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/hmpps-digital-prison-reporting-frontend/-/hmpps-digital-prison-reporting-frontend-3.7.2.tgz",
+      "integrity": "sha512-XjQJORBAhAPiEdG2Wfym30vy+zhKARhoA4kZoAA5LWFyYxUSr7JhplWF9lEs+NtGKTIDWoihNzH+AVmcrDrMPg==",
       "dependencies": {
         "agentkeepalive": "^4.5.0",
         "bunyan": "^1.8.15",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
   "dependencies": {
     "@aws-sdk/client-sqs": "^3.540.0",
     "@ministryofjustice/frontend": "^2.1.2",
-    "@ministryofjustice/hmpps-digital-prison-reporting-frontend": "^3.7.0",
+    "@ministryofjustice/hmpps-digital-prison-reporting-frontend": "^3.7.2",
     "@ministryofjustice/hmpps-non-associations-api": "https://github.com/ministryofjustice/hmpps-non-associations-api/releases/download/node-client-0.4.0/node-client.tgz",
     "agentkeepalive": "^4.5.0",
     "applicationinsights": "^2.9.5",

--- a/server/middleware/setUpWebSecurity.ts
+++ b/server/middleware/setUpWebSecurity.ts
@@ -36,9 +36,6 @@ export default function setUpWebSecurity(): Router {
           styleSrc: [
             "'self'",
             frontendComponentsHost,
-            // DPR
-            "'unsafe-hashes'",
-            "'sha256-eIUqgPTKhr3+WsA7FtEp+r8ITeTom+YQ/XO6GMvUtjc='",
             (_req: Request, res: Response) => `'nonce-${res.locals.cspNonce}'`,
           ],
           fontSrc: ["'self'", frontendComponentsHost],


### PR DESCRIPTION
[`v3.7.2`] doesn't use inline style so custom CSP to make it work is no longer necessary.

[`v3.7.2`]: https://github.com/ministryofjustice/hmpps-digital-prison-reporting-frontend/issues/82#issuecomment-2040040883