### PR TITLE
NON-318: Send alerts to dev channel

### DIFF
--- a/helm_deploy/hmpps-non-associations/values.yaml
+++ b/helm_deploy/hmpps-non-associations/values.yaml
@@ -81,4 +81,3 @@ generic-service:
 
 generic-prometheus-alerts:
   targetApplication: hmpps-non-associations
-  alertSeverity: digital-prison-service

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -26,5 +26,5 @@ generic-service:
     SUPPORT_URL: "https://support-dev.hmpps.service.justice.gov.uk"
 
 generic-prometheus-alerts:
-  alertSeverity: digital-prison-service-dev
+  alertSeverity: hmpps-non-associations-dev
   businessHoursOnly: true

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -24,5 +24,5 @@ generic-service:
     SUPPORT_URL: "https://support-preprod.hmpps.service.justice.gov.uk"
 
 generic-prometheus-alerts:
-  alertSeverity: digital-prison-service-dev
+  alertSeverity: hmpps-non-associations-preprod
   businessHoursOnly: true

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -20,4 +20,4 @@ generic-service:
     FEEDBACK_SURVEY_URL: "https://eu.surveymonkey.com/r/PJ8CKTH"
 
 generic-prometheus-alerts:
-  alertSeverity: digital-prison-service
+  alertSeverity: hmpps-non-associations-prod


### PR DESCRIPTION
Send alerts to our Slack dev channel (`#non-associations-dev`) instead of sending them to `#dps_alers`/`#dps_alerts_non_prod`.