### PR TITLE
NON-318: Use non-deprecated endpoint to load DPS micro-frontend components

### DIFF
--- a/integration_tests/mockApis/frontendComponents.ts
+++ b/integration_tests/mockApis/frontendComponents.ts
@@ -1,17 +1,21 @@
 import type { Response } from 'superagent'
 
 import { stubFor } from './wiremock'
-import type { Component, AvailableComponent } from '../../server/data/frontendComponentsClient'
+import type { AvailableComponent, Component } from '../../server/data/frontendComponentsClient'
+import { mockFrontendComponentResponse } from '../../server/data/testData/frontendComponents'
 
-const stubComponent = (name: AvailableComponent, component: Component): Promise<Response> =>
+const stubComponents = (components: Partial<Record<AvailableComponent, Component>> = {}): Promise<Response> =>
   stubFor({
     request: {
       method: 'GET',
-      urlPath: `/frontendComponents/${name}`,
+      urlPath: '/frontendComponents/components',
+      queryParameters: {
+        component: { includes: Object.keys(components).map(component => ({ equalTo: component })) },
+      },
     },
     response: {
       headers: { 'Content-Type': 'application/json' },
-      jsonBody: component,
+      jsonBody: mockFrontendComponentResponse(components),
     },
   })
 
@@ -47,13 +51,8 @@ const stubJavascript = (name: AvailableComponent, js: string): Promise<Response>
   })
 
 export default {
-  stubFallbackHeaderAndFooter(): Promise<Response[]> {
-    const empty: Component = {
-      html: '',
-      css: [],
-      javascript: [],
-    }
-    return Promise.all([stubComponent('header', empty), stubComponent('footer', empty)])
+  stubFallbackHeaderAndFooter(): Promise<Response> {
+    return stubComponents()
   },
   stubFrontendComponentsHeaderAndFooter(): Promise<Response[]> {
     return Promise.all([
@@ -61,15 +60,17 @@ export default {
       stubCSS('footer', 'footer { background: yellow }'),
       stubJavascript('header', 'window.FrontendComponentsHeaderDidLoad = true;'),
       stubJavascript('footer', 'window.FrontendComponentsFooterDidLoad = true;'),
-      stubComponent('header', {
-        html: '<header>HEADER</header>',
-        css: ['http://localhost:9091/frontendComponents/header.css'],
-        javascript: ['http://localhost:9091/frontendComponents/header.js'],
-      }),
-      stubComponent('footer', {
-        html: '<footer>FOOTER</footer>',
-        css: ['http://localhost:9091/frontendComponents/footer.css'],
-        javascript: ['http://localhost:9091/frontendComponents/footer.js'],
+      stubComponents({
+        header: {
+          html: '<header>HEADER</header>',
+          css: ['http://localhost:9091/frontendComponents/header.css'],
+          javascript: ['http://localhost:9091/frontendComponents/header.js'],
+        },
+        footer: {
+          html: '<footer>FOOTER</footer>',
+          css: ['http://localhost:9091/frontendComponents/footer.css'],
+          javascript: ['http://localhost:9091/frontendComponents/footer.js'],
+        },
       }),
     ])
   },

--- a/integration_tests/mockApis/wiremock.ts
+++ b/integration_tests/mockApis/wiremock.ts
@@ -10,6 +10,7 @@ export interface Mapping {
   request?: Partial<
     {
       method: 'GET' | 'POST' | 'PATCH' | 'PUT' | 'DELETE'
+      queryParameters: object
       bodyPatterns: { equalToJson: unknown }[]
     } & ({ url: string } | { urlPath: string } | { urlPathPattern: string } | { urlPattern: string })
   >

--- a/server/data/frontendComponentsClient.ts
+++ b/server/data/frontendComponentsClient.ts
@@ -1,4 +1,3 @@
-import logger from '../../logger'
 import config from '../config'
 import RestClient from './restClient'
 
@@ -10,15 +9,42 @@ export interface Component {
 
 export type AvailableComponent = 'header' | 'footer'
 
+export interface CaseLoad {
+  caseLoadId: string
+  description: string
+  type: string
+  caseloadFunction: string
+  currentlyActive: boolean
+}
+
+export interface Service {
+  id: string
+  heading: string
+  description: string
+  href: string
+  navEnabled: boolean
+}
+
+export interface ComponentsResponse extends Record<AvailableComponent, Component> {
+  meta: {
+    activeCaseLoad: CaseLoad
+    caseLoads: CaseLoad[]
+    services: Service[]
+  }
+}
+
 export default class FrontendComponentsClient {
   private static restClient(token: string): RestClient {
     return new RestClient('HMPPS Components Client', config.apis.frontendComponents, token)
   }
 
-  getComponent(component: AvailableComponent, userToken: string): Promise<Component> {
-    logger.info(`Getting frontend component ${component}`)
-    return FrontendComponentsClient.restClient(userToken).get<Component>({
-      path: `/${component}`,
+  getComponents<T extends AvailableComponent[]>(
+    components: T,
+    userToken: string,
+  ): Promise<Pick<ComponentsResponse, 'meta' | T[number]>> {
+    return FrontendComponentsClient.restClient(userToken).get({
+      path: '/components',
+      query: { component: components },
       headers: { 'x-user-token': userToken },
     })
   }

--- a/server/data/testData/frontendComponents.ts
+++ b/server/data/testData/frontendComponents.ts
@@ -1,0 +1,31 @@
+import type { AvailableComponent, CaseLoad, Component, ComponentsResponse } from '../frontendComponentsClient'
+
+const emptyComponent: Component = {
+  html: '',
+  css: [],
+  javascript: [],
+}
+
+const caseload: CaseLoad = {
+  caseLoadId: 'MDI',
+  description: 'Moorland (HMP & YOI)',
+  type: 'INST',
+  caseloadFunction: 'GENERAL',
+  currentlyActive: true,
+}
+
+// eslint-disable-next-line import/prefer-default-export
+export function mockFrontendComponentResponse(
+  components: Partial<Record<AvailableComponent, Component>> = {},
+): ComponentsResponse {
+  return {
+    header: emptyComponent,
+    footer: emptyComponent,
+    ...components,
+    meta: {
+      activeCaseLoad: caseload,
+      caseLoads: [caseload],
+      services: [],
+    },
+  }
+}

--- a/server/middleware/frontendComponents.test.ts
+++ b/server/middleware/frontendComponents.test.ts
@@ -1,0 +1,71 @@
+import type { NextFunction, Request, Response } from 'express'
+import nock from 'nock'
+
+import config from '../config'
+import type { Services } from '../services'
+import FrontendComponentsClient from '../data/frontendComponentsClient'
+import { mockFrontendComponentResponse } from '../data/testData/frontendComponents'
+import frontendComponents from './frontendComponents'
+
+describe('Frontend components middleware', () => {
+  const fakeApiClient = nock(config.apis.frontendComponents.url)
+  const frontendComponentsMiddleware = frontendComponents({
+    frontendComponentsClient: new FrontendComponentsClient(),
+  } as Services)
+  const userToken = 'user-token'
+
+  afterEach(() => {
+    nock.cleanAll()
+  })
+
+  it('should load frontend components', async () => {
+    fakeApiClient
+      .get('/components')
+      .query({ component: ['header', 'footer'] })
+      .matchHeader('authorization', `Bearer ${userToken}`)
+      .reply(
+        200,
+        mockFrontendComponentResponse({
+          header: {
+            html: 'header html',
+            css: ['/header.css'],
+            javascript: ['/header.js'],
+          },
+          footer: {
+            html: 'footer html',
+            css: ['/footer.css', '/footer-2.css'],
+            javascript: ['/footer.js'],
+          },
+        }),
+      )
+
+    const req = {} as Request
+    const res = { locals: { user: { token: userToken } } } as Response
+    const next: NextFunction = jest.fn()
+    await frontendComponentsMiddleware(req, res, next)
+
+    expect(next).toHaveBeenCalledWith()
+    expect(res.locals.feComponents).toEqual({
+      header: 'header html',
+      footer: 'footer html',
+      cssIncludes: ['/header.css', '/footer.css', '/footer-2.css'],
+      jsIncludes: ['/header.js', '/footer.js'],
+    })
+  })
+
+  it('should call next request handler even if frontend components failed to load', async () => {
+    fakeApiClient
+      .get('/components')
+      .query({ component: ['header', 'footer'] })
+      .matchHeader('authorization', `Bearer ${userToken}`)
+      .reply(401, { status: 401, userMessage: 'Unauthorized', developerMessage: 'Unauthorized' })
+
+    const req = {} as Request
+    const res = { locals: { user: { token: userToken } } } as Response
+    const next: NextFunction = jest.fn()
+    await frontendComponentsMiddleware(req, res, next)
+
+    expect(next).toHaveBeenCalledWith()
+    expect(res.locals.feComponents).toBeUndefined()
+  })
+})

--- a/server/middleware/frontendComponents.ts
+++ b/server/middleware/frontendComponents.ts
@@ -1,16 +1,16 @@
-import type { RequestHandler } from 'express'
+import type { NextFunction, Request, Response } from 'express'
 
 import logger from '../../logger'
 import type { Services } from '../services'
 
-export default function frontendComponents(services: Services): RequestHandler {
-  const { frontendComponentsClient } = services
-  return async (req, res, next) => {
+export default function frontendComponents({ frontendComponentsClient }: Services) {
+  return async (req: Request, res: Response, next: NextFunction): Promise<void> => {
     try {
-      const [header, footer] = await Promise.all([
-        frontendComponentsClient.getComponent('header', res.locals.user.token),
-        frontendComponentsClient.getComponent('footer', res.locals.user.token),
-      ])
+      const { header, footer } = await frontendComponentsClient.getComponents(
+        ['header', 'footer'],
+        res.locals.user.token,
+      )
+      // TODO: meta information from frontend components can be used to read active and available caseloads
       res.locals.feComponents = {
         header: header.html,
         footer: footer.html,
@@ -19,7 +19,7 @@ export default function frontendComponents(services: Services): RequestHandler {
       }
       next()
     } catch (error) {
-      logger.error(error, 'Failed to retrieve front end components')
+      logger.error(error, 'Failed to retrieve frontend components')
       next()
     }
   }

--- a/server/sanitisedError.test.ts
+++ b/server/sanitisedError.test.ts
@@ -1,4 +1,4 @@
-import sanitisedError, { UnsanitisedError, SanitisedError } from './sanitisedError'
+import sanitisedError, { type SanitisedError, type UnsanitisedError } from './sanitisedError'
 
 describe('sanitised error', () => {
   it('it should omit the request headers from the error object ', () => {
@@ -25,15 +25,15 @@ describe('sanitised error', () => {
       stack: 'stack description',
     } as unknown as UnsanitisedError
 
-    const e = new Error() as SanitisedError
-    e.message = 'Not Found'
-    e.text = 'details'
-    e.status = 404
-    e.headers = { date: 'Tue, 19 May 2020 15:16:20 GMT' }
-    e.data = { content: 'hello' }
-    e.stack = 'stack description'
+    const expectedError = new Error() as SanitisedError<{ content: string }>
+    expectedError.message = 'Not Found'
+    expectedError.text = 'details'
+    expectedError.status = 404
+    expectedError.headers = { date: 'Tue, 19 May 2020 15:16:20 GMT' }
+    expectedError.data = { content: 'hello' }
+    expectedError.stack = 'stack description'
 
-    expect(sanitisedError(error)).toEqual(e)
+    expect(sanitisedError(error)).toEqual(expectedError)
   })
 
   it('it should return the error message', () => {
@@ -45,7 +45,7 @@ describe('sanitised error', () => {
     expect(sanitisedError(error)).toHaveProperty('message', 'error description')
   })
 
-  it('it should return an empty Error instance for an unknown error structure', () => {
+  it('it should return an empty error for an unknown error structure', () => {
     const error = {
       property: 'unknown',
     } as unknown as UnsanitisedError

--- a/server/sanitisedError.ts
+++ b/server/sanitisedError.ts
@@ -1,5 +1,8 @@
 import type { ResponseError } from 'superagent'
 
+/**
+ * An error that may be safe to log as it omits sensitive request headers
+ */
 export interface SanitisedError<Data = unknown> extends Error {
   text?: string
   status?: number
@@ -9,10 +12,17 @@ export interface SanitisedError<Data = unknown> extends Error {
   message: string
 }
 
+/**
+ * An error as returned by superagemt, contains sensitive request headers
+ */
 export type UnsanitisedError = ResponseError
 
-export default function sanitise(error: UnsanitisedError): SanitisedError {
-  const e = new Error() as SanitisedError
+/**
+ * Converts an UnsanitisedError (superagent.ResponseError) into a simpler Error object,
+ * omitting request inforation (e.g. sensitive request headers)
+ */
+export default function sanitise<Data = unknown>(error: UnsanitisedError): SanitisedError<Data> {
+  const e = new Error() as SanitisedError<Data>
   e.message = error.message
   e.stack = error.stack
   if (error.response) {


### PR DESCRIPTION
`/header` & `/footer` endpoints are deprecated and [`/components`](https://frontend-components.hmpps.service.justice.gov.uk/api-docs/#/default/get_components) should be used instead

copied from [hmpps-incident-reporting#201](https://github.com/ministryofjustice/hmpps-incident-reporting/pull/201)