### PR TITLE
Security fix for `tmp`: GHSA-52f5-9888-hmc6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13563,7 +13563,9 @@
       "license": "MIT"
     },
     "node_modules/tmp": {
-      "version": "0.2.3",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
Bumped to version 0.2.5 (<= 0.2.3 are affected)

https://github.com/advisories/GHSA-52f5-9888-hmc6