### PR TITLE
Tidy up `tsconfig.json` files

### DIFF
--- a/assets/js/tsconfig.json
+++ b/assets/js/tsconfig.json
@@ -4,8 +4,6 @@
     "target": "es2020",
     "noEmit": true,
     "lib": ["dom", "dom.iterable", "es2020"],
-    "esModuleInterop": true,
-    "skipLibCheck": true,
     "sourceMap": true,
     "typeRoots": ["../../node_modules/@ministryofjustice/frontend-types"]
   },

--- a/integration_tests/tsconfig.json
+++ b/integration_tests/tsconfig.json
@@ -5,8 +5,6 @@
     "noEmit": true,
     "lib": ["dom", "es2022"],
     "types": ["cypress", "express", "express-session"],
-    "esModuleInterop": true,
-    "skipLibCheck": true,
     "sourceMap": false,
     "typeRoots": ["../server/@types", "../node_modules/@types", "../node_modules"]
   },

--- a/integration_tests/tsconfig.json
+++ b/integration_tests/tsconfig.json
@@ -3,7 +3,8 @@
   "extends": "../tsconfig.json",
   "compilerOptions": {
     "noEmit": true,
-    "lib": ["dom", "es2022"],
+    "target": "es2024",
+    "lib": ["dom", "es2024"],
     "types": ["cypress", "express", "express-session"],
     "sourceMap": false,
     "typeRoots": ["../server/@types", "../node_modules/@types", "../node_modules"]

--- a/renovate.json
+++ b/renovate.json
@@ -13,7 +13,7 @@
       "matchUpdateTypes": ["minor", "patch"],
       "groupName": "all non major NPM dependencies",
       "groupSlug": "all-npm-minor-patch",
-      "stabilityDays": 3
+      "stabilityDays": 7
     },
     {
       "matchDepTypes": ["engines"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,6 @@
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
     "noImplicitAny": true,
-    "experimentalDecorators": true,
     "typeRoots": ["./server/@types", "./node_modules/@types"]
   },
   "exclude": [


### PR DESCRIPTION
- removed following redundant settings [already set in the parent config](https://github.com/tsconfig/bases/blob/bc304579bf23daf9561a138ef3a11518da31b9d1/bases/node24.json#L19-L20):
  - `"esModuleInterop": true`
  - `"skipLibCheck": true`
- removed `"experimentalDecorators": true` setting, it shouldn't be used
- ensure integration tests `tsconfig.json` uses version of JS for the lib that matches target

Also cherry-picked [this renovate config change](https://github.com/ministryofjustice/hmpps-template-typescript/commit/bfd4e449c4a55b070557fe80967038eebd365687) from TS template.