### PR TITLE
CDPS-1906: Add both old and new DPS home pages to Content-Security-Policy `form-action` directive

### DIFF
--- a/feature.env
+++ b/feature.env
@@ -14,6 +14,7 @@ HMPPS_NON_ASSOCIATIONS_API_URL=http://localhost:9091/nonAssociationsApi
 COMPONENT_API_URL=http://localhost:9091/frontendComponents
 
 DPS_URL=http://localhost:3000
+NEW_DPS_URL=http://localhost:3000
 
 API_CLIENT_ID=clientid
 API_CLIENT_SECRET=clientsecret

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -23,6 +23,7 @@ generic-service:
 
     INGRESS_URL: "https://non-associations-dev.hmpps.service.justice.gov.uk"
     DPS_URL: "https://digital-dev.prison.service.justice.gov.uk"
+    NEW_DPS_URL: "https://dps-dev.prison.service.justice.gov.uk"
     SUPPORT_URL: "https://support-dev.hmpps.service.justice.gov.uk"
 
 generic-prometheus-alerts:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -21,6 +21,7 @@ generic-service:
 
     INGRESS_URL: "https://non-associations-preprod.hmpps.service.justice.gov.uk"
     DPS_URL: "https://digital-preprod.prison.service.justice.gov.uk"
+    NEW_DPS_URL: "https://dps-preprod.prison.service.justice.gov.uk"
     SUPPORT_URL: "https://support-preprod.hmpps.service.justice.gov.uk"
 
 generic-prometheus-alerts:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -19,6 +19,7 @@ generic-service:
 
     INGRESS_URL: "https://non-associations.hmpps.service.justice.gov.uk"
     DPS_URL: "https://digital.prison.service.justice.gov.uk"
+    NEW_DPS_URL: "https://dps.prison.service.justice.gov.uk"
     SUPPORT_URL: "https://support.hmpps.service.justice.gov.uk"
     FEEDBACK_SURVEY_URL: "https://www.smartsurvey.co.uk/s/H10VXN/"
 

--- a/server/config.ts
+++ b/server/config.ts
@@ -143,6 +143,7 @@ export default {
   teamEmail: get('TEAM_EMAIL', 'info@digital.justice.gov.uk'),
   ingressUrl: get('INGRESS_URL', 'http://localhost:3000', requiredInProduction),
   dpsUrl: get('DPS_URL', 'http://dps.local', requiredInProduction),
+  newDpsUrl: get('NEW_DPS_URL', 'http://dps.local', requiredInProduction),
   feedbackSurveyUrl: get('FEEDBACK_SURVEY_URL', 'http://feedback.dps.local'),
   supportUrl: get('SUPPORT_URL', 'http://support.dps.local', requiredInProduction),
 }

--- a/server/middleware/setUpWebSecurity.ts
+++ b/server/middleware/setUpWebSecurity.ts
@@ -18,6 +18,7 @@ export default function setUpWebSecurity(): Router {
 
   const authHost = new URL(config.apis.hmppsAuth.externalUrl).hostname
   const dpsHost = new URL(config.dpsUrl).hostname
+  const newDpsHost = new URL(config.newDpsUrl).hostname
   const frontendComponentsHost = new URL(config.apis.frontendComponents.url).hostname
 
   router.use(
@@ -48,7 +49,7 @@ export default function setUpWebSecurity(): Router {
             (_req: Request, res: Response) => `'nonce-${res.locals.cspNonce}'`,
           ],
           fontSrc: ["'self'", frontendComponentsHost],
-          formAction: ["'self'", authHost, dpsHost],
+          formAction: ["'self'", authHost, dpsHost, newDpsHost],
           connectSrc: [
             "'self'",
             '*.google-analytics.com',


### PR DESCRIPTION
… so that prisoner search will once again work from the header. CDPS team moved the feature between services, but there are redirects involved so both domains are needed.