### PR TITLE
IR-1635: Use system token for Prison API prisoner photo requests

### DIFF
--- a/server/data/prisonApi.test.ts
+++ b/server/data/prisonApi.test.ts
@@ -8,11 +8,11 @@ describe('PrisonApi', () => {
   let prisonApi: nock.Scope
   let prisonApiClient: PrisonApi
 
-  const accessToken = 'test token'
+  const systemToken = 'test token'
 
   beforeEach(() => {
     prisonApi = nock(config.apis.hmppsPrisonApi.url)
-    prisonApiClient = new PrisonApi(accessToken)
+    prisonApiClient = new PrisonApi(systemToken)
   })
 
   afterEach(() => {
@@ -27,7 +27,7 @@ describe('PrisonApi', () => {
       prisonApi
         .get(`/api/bookings/offenderNo/${prisonerNumber}/image/data`)
         .query({ fullSizeImage: 'false' })
-        .matchHeader('authorization', `Bearer ${accessToken}`)
+        .matchHeader('authorization', `Bearer ${systemToken}`)
         .reply(200, imageData, { 'Content-Type': 'image/jpeg' })
 
       const response = await prisonApiClient.getPhoto(prisonerNumber)
@@ -38,7 +38,7 @@ describe('PrisonApi', () => {
       prisonApi
         .get(`/api/bookings/offenderNo/${prisonerNumber}/image/data`)
         .query({ fullSizeImage: 'false' })
-        .matchHeader('authorization', `Bearer ${accessToken}`)
+        .matchHeader('authorization', `Bearer ${systemToken}`)
         .thrice()
         .reply(404)
 
@@ -50,7 +50,7 @@ describe('PrisonApi', () => {
       prisonApi
         .get(`/api/bookings/offenderNo/${prisonerNumber}/image/data`)
         .query({ fullSizeImage: 'false' })
-        .matchHeader('authorization', `Bearer ${accessToken}`)
+        .matchHeader('authorization', `Bearer ${systemToken}`)
         .thrice()
         .reply(403)
 
@@ -62,7 +62,7 @@ describe('PrisonApi', () => {
       prisonApi
         .get(`/api/bookings/offenderNo/${prisonerNumber}/image/data`)
         .query({ fullSizeImage: 'false' })
-        .matchHeader('authorization', `Bearer ${accessToken}`)
+        .matchHeader('authorization', `Bearer ${systemToken}`)
         .thrice()
         .reply(500)
 
@@ -76,7 +76,7 @@ describe('PrisonApi', () => {
     it('should return an object', async () => {
       prisonApi
         .get(`/api/users/${username}`)
-        .matchHeader('authorization', `Bearer ${accessToken}`)
+        .matchHeader('authorization', `Bearer ${systemToken}`)
         .reply(200, staffMary)
 
       const response = await prisonApiClient.getStaffDetails(username)
@@ -84,21 +84,21 @@ describe('PrisonApi', () => {
     })
 
     it('should return null if not found', async () => {
-      prisonApi.get(`/api/users/${username}`).matchHeader('authorization', `Bearer ${accessToken}`).thrice().reply(404)
+      prisonApi.get(`/api/users/${username}`).matchHeader('authorization', `Bearer ${systemToken}`).thrice().reply(404)
 
       const response = await prisonApiClient.getStaffDetails(username)
       expect(response).toBeNull()
     })
 
     it('should return null if unauthorised', async () => {
-      prisonApi.get(`/api/users/${username}`).matchHeader('authorization', `Bearer ${accessToken}`).thrice().reply(403)
+      prisonApi.get(`/api/users/${username}`).matchHeader('authorization', `Bearer ${systemToken}`).thrice().reply(403)
 
       const response = await prisonApiClient.getStaffDetails(username)
       expect(response).toBeNull()
     })
 
     it('should throw when it receives another error', async () => {
-      prisonApi.get(`/api/users/${username}`).matchHeader('authorization', `Bearer ${accessToken}`).thrice().reply(500)
+      prisonApi.get(`/api/users/${username}`).matchHeader('authorization', `Bearer ${systemToken}`).thrice().reply(500)
 
       await expect(prisonApiClient.getStaffDetails(username)).rejects.toThrow('Internal Server Error')
     })

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -4,7 +4,6 @@ import { Router } from 'express'
 import config from '../config'
 import flashMessages from '../middleware/flashMessages'
 import type { Services } from '../services'
-import PrisonApi from '../data/prisonApi'
 import prisonerSearchRoutes from './prisonerSearch'
 import addRoutes from './add'
 import closeRoutes from './close'
@@ -29,11 +28,9 @@ export default function routes(services: Services): Router {
   })
 
   router.get(urlTemplates.prisonerPhoto, async (req, res) => {
-    const { user } = res.locals
     const { prisonerNumber } = req.params
 
-    const prisonApi = new PrisonApi(user.token)
-    const photoData = await prisonApi.getPhoto(prisonerNumber)
+    const photoData = await res.locals.apis.prisonApi.getPhoto(prisonerNumber)
 
     const oneDay = 86400 as const
     res.setHeader('Cache-Control', `private, max-age=${oneDay}`)

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -2,6 +2,7 @@ import flash from 'connect-flash'
 import { Router } from 'express'
 
 import config from '../config'
+import PrisonApi from '../data/prisonApi'
 import flashMessages from '../middleware/flashMessages'
 import type { Services } from '../services'
 import prisonerSearchRoutes from './prisonerSearch'
@@ -12,6 +13,7 @@ import viewRoutes from './view'
 import updateRoutes from './update'
 
 export default function routes(services: Services): Router {
+  const { hmppsAuthClient } = services
   const router = Router({ mergeParams: true })
 
   router.use(flash())
@@ -30,7 +32,10 @@ export default function routes(services: Services): Router {
   router.get(urlTemplates.prisonerPhoto, async (req, res) => {
     const { prisonerNumber } = req.params
 
-    const photoData = await res.locals.apis.prisonApi.getPhoto(prisonerNumber)
+    const { user } = res.locals
+    const systemToken = await hmppsAuthClient.getToken(user.username)
+    const prisonApi = new PrisonApi(systemToken)
+    const photoData = await prisonApi.getPhoto(prisonerNumber)
 
     const oneDay = 86400 as const
     res.setHeader('Cache-Control', `private, max-age=${oneDay}`)


### PR DESCRIPTION
# IR-1635: Use client credentials token for Prison API prisoner photo requests

## Summary

Fixes 403 errors when fetching prisoner photos for users who have global search access but do not have the specific establishment in their active caseload.

Prison API's `/api/bookings/offenderNo/{prisonerNumber}/image/data` endpoint enforces caseload-level access when called with a user's delegated OAuth token. This meant that users with global search permissions — who are legitimately allowed to view prisoners across establishments — would receive a 403 when viewing an incident involving a prisoner not in their active caseload.

The fix is to call Prison API with a **client credentials (system) token** for image fetches. The decision of whether to display the photo remains with the frontend application.

## Changes

### `server/routes/index.ts`

The prisoner photo route (`GET /prisoner/:prisonerNumber/photo.jpeg`) was previously constructing a `PrisonApi` instance using the **user's delegated OAuth token**:

```ts
// Before
const { user } = res.locals
const prisonApi = new PrisonApi(user.token)
const photoData = await prisonApi.getPhoto(prisonerNumber)
```

It now explicitly fetches a **client credentials token** via `hmppsAuthClient.getToken(user.username)` and constructs a fresh `PrisonApi` instance with it:

```ts
// After
const { user } = res.locals
const systemToken = await hmppsAuthClient.getToken(user.username)
const prisonApi = new PrisonApi(systemToken)
const photoData = await prisonApi.getPhoto(prisonerNumber)
```

`hmppsAuthClient` is destructured from `services` at router initialisation time and is the same auth client used by `setSystemToken` middleware throughout the application. Using `getToken(username)` retrieves a cached client credentials token scoped to the user's session — it is not the user's own token.

This pattern is consistent with other places in the codebase that construct `PrisonApi` outside of `res.locals.apis` (e.g. `server/middleware/updateActiveAgencies.ts`).

### `server/data/prisonApi.test.ts`

Renamed the local test variable `accessToken` → `systemToken` across all test cases. This is a cosmetic change only — no test logic was altered — but it accurately reflects the token type that `PrisonApi` should be constructed with, removing a misleading name that implied a user access token.

## Why not use `res.locals.apis.prisonApi`?

An intermediate approach using the pre-built `res.locals.apis.prisonApi` instance (populated by `setApis` middleware) was explored but not taken forward. The explicit `hmppsAuthClient.getToken` approach was preferred because:

- It makes the token type unambiguous at the call site — a reader does not need to trace through middleware setup to understand which token is in use.
- It is self-contained within the route handler, with no dependency on the `setApis` middleware having run and populated `res.locals.apis` correctly.
- It is consistent with how other background/auxiliary operations (e.g. `updateActiveAgencies`) obtain a system token directly from `hmppsAuthClient`.

## Testing

- All existing `prisonApi.test.ts` tests continue to pass (only variable name updated).
- Manually verified that the photo endpoint no longer returns 403 for users with global search access viewing prisoners outside their active caseload.

## Risk

Low. The change targets a single auxiliary route handler. The token type (`hmppsAuthClient.getToken(username)`) is the same client credentials token used by other system-to-service calls throughout the application. No new behaviour is introduced for users within their caseload.
